### PR TITLE
Add centralized settings loader

### DIFF
--- a/libs/config/policy_loader.py
+++ b/libs/config/policy_loader.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
-import os
 import yaml
 from pathlib import Path
 
+from libs.config.settings import Settings
+
 class PolicyLoader:
     def __init__(self):
-        self.policy_path = os.getenv("POLICY_PATH", "policies/default.yaml")
+        self.policy_path = Settings().policy_path
         self._cache = None
         self._last_mtime = 0
 

--- a/libs/config/settings.py
+++ b/libs/config/settings.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pydantic import ConfigDict
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    policy_path: str = "policies/default.yaml"
+    detector_model: str = "yolov8n.pt"
+    detection_confidence_threshold: float = 0.45
+    detector_device: str = "cpu"
+    tracker_fps: float = 30
+    tracker_max_age: int = 30
+    tracker_n_init: int = 3
+    tracker_max_cosine_distance: float = 0.4
+    camera_id: str = "cam_01"
+
+    model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+settings = Settings()


### PR DESCRIPTION
Adds a centralized `Settings` class backed by `pydantic-settings` so configuration values can be loaded from the environment or `.env` in one place. The policy loader now reads its path from that settings object while keeping the existing default behavior, and the focused policy loader tests continue to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized configuration system for managing application settings via environment variables or `.env` file.
  * Configurable parameters: policy path, detector model, detection confidence threshold, tracker timing and thresholds, and camera ID.

* **Refactor**
  * Internal configuration loading mechanism updated to use new settings module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Devnil434/Eagle-Real-Time-Semantic-Surveillance-using-Detection-Tracking-Reasoning/pull/33)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->