### PR TITLE
Add Redis track inspection CLI

### DIFF
--- a/scripts/inspect_tracks.py
+++ b/scripts/inspect_tracks.py
@@ -15,6 +15,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from typing import Any, Iterable
+from urllib.parse import urlsplit, urlunsplit
 
 import redis
 
@@ -67,14 +68,17 @@ def _track_id_from_key(key: str) -> int:
     return int(key.rsplit(":", 1)[-1])
 
 
-def _normalise_event(event: dict[str, Any]) -> dict[str, Any]:
+def _normalise_event(event: dict[str, Any]) -> dict[str, Any] | None:
     normalised = dict(event)
     if "event" in normalised:
         normalised["event"] = str(normalised["event"])
-    if "track_id" in normalised:
-        normalised["track_id"] = int(normalised["track_id"])
-    if "frame_id" in normalised:
-        normalised["frame_id"] = int(normalised["frame_id"])
+    try:
+        if "track_id" in normalised:
+            normalised["track_id"] = int(normalised["track_id"])
+        if "frame_id" in normalised:
+            normalised["frame_id"] = int(normalised["frame_id"])
+    except (TypeError, ValueError):
+        return None
     return normalised
 
 
@@ -113,6 +117,8 @@ def load_events(
             if not isinstance(event, dict):
                 continue
             normalised = _normalise_event(event)
+            if normalised is None:
+                continue
             if track_id is not None and normalised.get("track_id") != track_id:
                 continue
             events.append(normalised)
@@ -169,13 +175,46 @@ def inspect_tracks(
     ]
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("--last must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("--last must be greater than 0")
+    return parsed
+
+
+def _safe_redis_display_url(redis_url: str) -> str:
+    parsed = urlsplit(redis_url)
+    if not parsed.scheme or not parsed.hostname:
+        return redis_url
+
+    host = parsed.hostname
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return urlunsplit((parsed.scheme, host, "", "", ""))
+
+
+def build_json_payload(
+    summaries: list[TrackSummary],
+    camera_id: str,
+    redis_url: str,
+) -> dict[str, Any]:
+    return {
+        "camera_id": camera_id,
+        "redis_url": _safe_redis_display_url(redis_url),
+        "tracks": [summary.to_dict(include_events=True) for summary in summaries],
+    }
+
+
 def render_text(
     summaries: list[TrackSummary],
     camera_id: str,
     redis_url: str,
     show_event_rows: bool,
 ) -> str:
-    host = redis_url.replace("redis://", "")
+    host = _safe_redis_display_url(redis_url).replace("redis://", "")
     lines = [f"Active tracks in {camera_id} (Redis @ {host})", ""]
 
     if not summaries:
@@ -225,7 +264,7 @@ def parse_args() -> argparse.Namespace:
         help="Camera id to inspect. Defaults to cam_01.",
     )
     parser.add_argument("--track", type=int, help="Only inspect one track id.")
-    parser.add_argument("--last", type=int, help="Limit event rows to the last N events.")
+    parser.add_argument("--last", type=_positive_int, help="Limit event rows to the last N events.")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     return parser.parse_args()
 
@@ -241,12 +280,7 @@ def main() -> None:
     )
 
     if args.json:
-        payload = {
-            "camera_id": args.camera,
-            "redis_url": args.redis_url,
-            "tracks": [summary.to_dict(include_events=True) for summary in summaries],
-        }
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(build_json_payload(summaries, args.camera, args.redis_url), indent=2))
         return
 
     print(

--- a/scripts/inspect_tracks.py
+++ b/scripts/inspect_tracks.py
@@ -1,0 +1,263 @@
+"""
+Inspect track memory stored by the Eagle Redis memory layer.
+
+Examples:
+    python scripts/inspect_tracks.py
+    python scripts/inspect_tracks.py --track 3
+    python scripts/inspect_tracks.py --track 3 --last 10
+    python scripts/inspect_tracks.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+import redis
+
+DEFAULT_CAMERA_ID = "cam_01"
+DEFAULT_REDIS_URL = "redis://localhost:6379"
+
+
+@dataclass
+class TrackSummary:
+    camera_id: str
+    track_id: int
+    state: str = "UNKNOWN"
+    event_count: int = 0
+    dwell_time_seconds: float = 0.0
+    zone: str = "unknown"
+    action_summary: str = "no events"
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self, include_events: bool = True) -> dict[str, Any]:
+        data = {
+            "camera_id": self.camera_id,
+            "track_id": self.track_id,
+            "state": self.state,
+            "event_count": self.event_count,
+            "dwell_time_seconds": self.dwell_time_seconds,
+            "zone": self.zone,
+            "action_summary": self.action_summary,
+        }
+        if include_events:
+            data["events"] = self.events
+        return data
+
+
+def _decode(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+def _loads(raw: Any) -> Any:
+    return json.loads(_decode(raw))
+
+
+def _iter_keys(redis_client: Any, pattern: str) -> list[str]:
+    keys = redis_client.keys(pattern)
+    return sorted(_decode(key) for key in keys)
+
+
+def _track_id_from_key(key: str) -> int:
+    return int(key.rsplit(":", 1)[-1])
+
+
+def _normalise_event(event: dict[str, Any]) -> dict[str, Any]:
+    normalised = dict(event)
+    if "event" in normalised:
+        normalised["event"] = str(normalised["event"])
+    if "track_id" in normalised:
+        normalised["track_id"] = int(normalised["track_id"])
+    if "frame_id" in normalised:
+        normalised["frame_id"] = int(normalised["frame_id"])
+    return normalised
+
+
+def _event_sort_key(event: dict[str, Any]) -> tuple[int, float]:
+    return (
+        int(event.get("frame_id", 0)),
+        float(event.get("timestamp_ms", 0.0)),
+    )
+
+
+def load_track_record(redis_client: Any, camera_id: str, track_id: int) -> dict[str, Any] | None:
+    raw = redis_client.get(f"track:{camera_id}:{track_id}")
+    return _loads(raw) if raw else None
+
+
+def load_events(
+    redis_client: Any,
+    camera_id: str,
+    track_id: int | None = None,
+) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for key in _iter_keys(redis_client, f"event:{camera_id}:*"):
+        raw = redis_client.get(key)
+        if not raw:
+            continue
+
+        try:
+            stored_events = _loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        if not isinstance(stored_events, list):
+            continue
+
+        for event in stored_events:
+            if not isinstance(event, dict):
+                continue
+            normalised = _normalise_event(event)
+            if track_id is not None and normalised.get("track_id") != track_id:
+                continue
+            events.append(normalised)
+
+    return sorted(events, key=_event_sort_key)
+
+
+def build_action_summary(events: Iterable[dict[str, Any]]) -> str:
+    names = [str(event.get("event", "UNKNOWN")).lower() for event in events]
+    return " -> ".join(names) if names else "no events"
+
+
+def build_track_summary(
+    redis_client: Any,
+    camera_id: str,
+    track_id: int,
+    last: int | None = None,
+) -> TrackSummary:
+    record = load_track_record(redis_client, camera_id, track_id) or {}
+    events = load_events(redis_client, camera_id, track_id=track_id)
+    if last is not None:
+        events = events[-last:]
+
+    zones = record.get("zones_present") or []
+    if not zones and events:
+        zones = events[-1].get("zones_present") or []
+
+    return TrackSummary(
+        camera_id=camera_id,
+        track_id=track_id,
+        state=str(record.get("state", "UNKNOWN")),
+        event_count=len(events),
+        dwell_time_seconds=float(record.get("dwell_time_seconds", 0.0)),
+        zone=", ".join(zones) if zones else "unknown",
+        action_summary=build_action_summary(events),
+        events=events,
+    )
+
+
+def list_track_ids(redis_client: Any, camera_id: str) -> list[int]:
+    return [_track_id_from_key(key) for key in _iter_keys(redis_client, f"track:{camera_id}:*")]
+
+
+def inspect_tracks(
+    redis_client: Any,
+    camera_id: str,
+    track_id: int | None = None,
+    last: int | None = None,
+) -> list[TrackSummary]:
+    track_ids = [track_id] if track_id is not None else list_track_ids(redis_client, camera_id)
+    return [
+        build_track_summary(redis_client, camera_id, current_track_id, last=last)
+        for current_track_id in track_ids
+    ]
+
+
+def render_text(
+    summaries: list[TrackSummary],
+    camera_id: str,
+    redis_url: str,
+    show_event_rows: bool,
+) -> str:
+    host = redis_url.replace("redis://", "")
+    lines = [f"Active tracks in {camera_id} (Redis @ {host})", ""]
+
+    if not summaries:
+        lines.append("No active tracks found.")
+        return "\n".join(lines)
+
+    for summary in summaries:
+        lines.extend(
+            [
+                f"Track #{summary.track_id}",
+                f"events: {summary.event_count}",
+                f"dwell: {summary.dwell_time_seconds:.1f}s",
+                f"zone: {summary.zone}",
+                f"summary: {summary.action_summary}",
+            ]
+        )
+
+        if show_event_rows:
+            lines.append("event rows:")
+            if summary.events:
+                for event in summary.events:
+                    lines.append(
+                        "  - frame {frame}: {event} dwell={dwell:.1f}s zones={zones}".format(
+                            frame=event.get("frame_id", "?"),
+                            event=event.get("event", "UNKNOWN"),
+                            dwell=float(event.get("dwell_time_seconds", 0.0)),
+                            zones=", ".join(event.get("zones_present") or []) or "unknown",
+                        )
+                    )
+            else:
+                lines.append("  - none")
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Inspect Eagle track records stored in Redis.")
+    parser.add_argument(
+        "--redis-url",
+        default=os.getenv("REDIS_URL", DEFAULT_REDIS_URL),
+        help="Redis URL. Defaults to REDIS_URL or redis://localhost:6379.",
+    )
+    parser.add_argument(
+        "--camera",
+        default=os.getenv("CAMERA_ID", DEFAULT_CAMERA_ID),
+        help="Camera id to inspect. Defaults to cam_01.",
+    )
+    parser.add_argument("--track", type=int, help="Only inspect one track id.")
+    parser.add_argument("--last", type=int, help="Limit event rows to the last N events.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    redis_client = redis.from_url(args.redis_url)
+    summaries = inspect_tracks(
+        redis_client,
+        camera_id=args.camera,
+        track_id=args.track,
+        last=args.last,
+    )
+
+    if args.json:
+        payload = {
+            "camera_id": args.camera,
+            "redis_url": args.redis_url,
+            "tracks": [summary.to_dict(include_events=True) for summary in summaries],
+        }
+        print(json.dumps(payload, indent=2))
+        return
+
+    print(
+        render_text(
+            summaries,
+            camera_id=args.camera,
+            redis_url=args.redis_url,
+            show_event_rows=args.track is not None,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inspect_tracks.py
+++ b/tests/test_inspect_tracks.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 import sys
 
+import fakeredis
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -19,7 +20,6 @@ from scripts.inspect_tracks import (
 
 @pytest.fixture()
 def fake_redis():
-    fakeredis = pytest.importorskip("fakeredis")
     return fakeredis.FakeRedis()
 
 
@@ -30,7 +30,7 @@ def _seed_track(fake_redis, track_id: int = 3) -> None:
             {
                 "camera_id": "cam_01",
                 "track_id": track_id,
-                "global_id": "gid-3",
+                "global_id": f"gid-{track_id}",
                 "state": "ACTIVE",
                 "dwell_time_seconds": 4.1,
                 "zones_present": ["safe_corridor"],

--- a/tests/test_inspect_tracks.py
+++ b/tests/test_inspect_tracks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 from pathlib import Path
 import sys
@@ -8,7 +9,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.inspect_tracks import inspect_tracks, render_text
+from scripts.inspect_tracks import (
+    _positive_int,
+    build_json_payload,
+    inspect_tracks,
+    render_text,
+)
 
 
 @pytest.fixture()
@@ -109,19 +115,62 @@ def test_inspect_tracks_limits_recent_events(fake_redis):
     assert summaries[0].action_summary == "active"
 
 
+def test_inspect_tracks_skips_malformed_events(fake_redis):
+    _seed_track(fake_redis)
+    _seed_events(fake_redis)
+    fake_redis.set(
+        "event:cam_01:3",
+        json.dumps(
+            [
+                {
+                    "event": "BROKEN",
+                    "track_id": "not-an-int",
+                    "frame_id": 3,
+                    "timestamp_ms": 3000.0,
+                    "zones_present": ["safe_corridor"],
+                },
+                {
+                    "event": "STILL_ACTIVE",
+                    "track_id": 3,
+                    "frame_id": "4",
+                    "timestamp_ms": 4000.0,
+                    "zones_present": ["safe_corridor"],
+                },
+            ]
+        ),
+    )
+
+    summaries = inspect_tracks(fake_redis, camera_id="cam_01", track_id=3)
+
+    assert summaries[0].event_count == 3
+    assert summaries[0].events[-1]["event"] == "STILL_ACTIVE"
+    assert summaries[0].events[-1]["frame_id"] == 4
+
+
+def test_positive_int_rejects_zero_and_negative_values():
+    assert _positive_int("2") == 2
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        _positive_int("0")
+    with pytest.raises(argparse.ArgumentTypeError):
+        _positive_int("-1")
+
+
 def test_json_payload_is_machine_readable(fake_redis):
     _seed_track(fake_redis)
     _seed_events(fake_redis)
     summaries = inspect_tracks(fake_redis, camera_id="cam_01", track_id=3)
 
-    payload = {
-        "camera_id": "cam_01",
-        "redis_url": "redis://localhost:6379",
-        "tracks": [summary.to_dict() for summary in summaries],
-    }
+    payload = build_json_payload(
+        summaries,
+        camera_id="cam_01",
+        redis_url="redis://user:secret@localhost:6379/0",
+    )
 
     encoded = json.dumps(payload)
     decoded = json.loads(encoded)
+    assert decoded["redis_url"] == "redis://localhost:6379"
+    assert "secret" not in encoded
     assert decoded["tracks"][0]["track_id"] == 3
     assert decoded["tracks"][0]["events"][0]["event"] == "BORN"
 
@@ -139,6 +188,23 @@ def test_text_render_includes_detail_rows_for_single_track(fake_redis):
     )
 
     assert "Track #3" in output
+    assert "Redis @ localhost:6379" in output
     assert "summary: born -> active" in output
     assert "event rows:" in output
     assert "frame 2: ACTIVE" in output
+
+
+def test_text_render_redacts_redis_credentials(fake_redis):
+    _seed_track(fake_redis)
+    summaries = inspect_tracks(fake_redis, camera_id="cam_01", track_id=3)
+
+    output = render_text(
+        summaries,
+        camera_id="cam_01",
+        redis_url="redis://user:secret@redis.example.com:6380/0",
+        show_event_rows=False,
+    )
+
+    assert "redis.example.com:6380" in output
+    assert "user" not in output
+    assert "secret" not in output

--- a/tests/test_inspect_tracks.py
+++ b/tests/test_inspect_tracks.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.inspect_tracks import inspect_tracks, render_text
+
+
+@pytest.fixture()
+def fake_redis():
+    fakeredis = pytest.importorskip("fakeredis")
+    return fakeredis.FakeRedis()
+
+
+def _seed_track(fake_redis, track_id: int = 3) -> None:
+    fake_redis.set(
+        f"track:cam_01:{track_id}",
+        json.dumps(
+            {
+                "camera_id": "cam_01",
+                "track_id": track_id,
+                "global_id": "gid-3",
+                "state": "ACTIVE",
+                "dwell_time_seconds": 4.1,
+                "zones_present": ["safe_corridor"],
+            }
+        ),
+    )
+
+
+def _seed_events(fake_redis, track_id: int = 3) -> None:
+    fake_redis.set(
+        "event:cam_01:1",
+        json.dumps(
+            [
+                {
+                    "event": "BORN",
+                    "track_id": track_id,
+                    "frame_id": 1,
+                    "timestamp_ms": 1000.0,
+                    "dwell_time_seconds": 0.0,
+                    "zones_present": ["safe_corridor"],
+                }
+            ]
+        ),
+    )
+    fake_redis.set(
+        "event:cam_01:2",
+        json.dumps(
+            [
+                {
+                    "event": "ACTIVE",
+                    "track_id": track_id,
+                    "frame_id": 2,
+                    "timestamp_ms": 2000.0,
+                    "dwell_time_seconds": 4.1,
+                    "zones_present": ["safe_corridor"],
+                },
+                {
+                    "event": "ACTIVE",
+                    "track_id": 99,
+                    "frame_id": 2,
+                    "timestamp_ms": 2000.0,
+                    "dwell_time_seconds": 1.0,
+                    "zones_present": ["restricted_door"],
+                },
+            ]
+        ),
+    )
+
+
+def test_inspect_tracks_lists_active_tracks(fake_redis):
+    _seed_track(fake_redis)
+    _seed_events(fake_redis)
+
+    summaries = inspect_tracks(fake_redis, camera_id="cam_01")
+
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.track_id == 3
+    assert summary.event_count == 2
+    assert summary.zone == "safe_corridor"
+    assert summary.action_summary == "born -> active"
+
+
+def test_inspect_tracks_filters_single_track(fake_redis):
+    _seed_track(fake_redis, track_id=3)
+    _seed_track(fake_redis, track_id=4)
+    _seed_events(fake_redis, track_id=3)
+
+    summaries = inspect_tracks(fake_redis, camera_id="cam_01", track_id=3)
+
+    assert [summary.track_id for summary in summaries] == [3]
+
+
+def test_inspect_tracks_limits_recent_events(fake_redis):
+    _seed_track(fake_redis)
+    _seed_events(fake_redis)
+
+    summaries = inspect_tracks(fake_redis, camera_id="cam_01", track_id=3, last=1)
+
+    assert summaries[0].event_count == 1
+    assert summaries[0].events[0]["frame_id"] == 2
+    assert summaries[0].action_summary == "active"
+
+
+def test_json_payload_is_machine_readable(fake_redis):
+    _seed_track(fake_redis)
+    _seed_events(fake_redis)
+    summaries = inspect_tracks(fake_redis, camera_id="cam_01", track_id=3)
+
+    payload = {
+        "camera_id": "cam_01",
+        "redis_url": "redis://localhost:6379",
+        "tracks": [summary.to_dict() for summary in summaries],
+    }
+
+    encoded = json.dumps(payload)
+    decoded = json.loads(encoded)
+    assert decoded["tracks"][0]["track_id"] == 3
+    assert decoded["tracks"][0]["events"][0]["event"] == "BORN"
+
+
+def test_text_render_includes_detail_rows_for_single_track(fake_redis):
+    _seed_track(fake_redis)
+    _seed_events(fake_redis)
+    summaries = inspect_tracks(fake_redis, camera_id="cam_01", track_id=3)
+
+    output = render_text(
+        summaries,
+        camera_id="cam_01",
+        redis_url="redis://localhost:6379",
+        show_event_rows=True,
+    )
+
+    assert "Track #3" in output
+    assert "summary: born -> active" in output
+    assert "event rows:" in output
+    assert "frame 2: ACTIVE" in output


### PR DESCRIPTION
## Summary
- add `scripts/inspect_tracks.py` to inspect active Redis-backed tracks for a camera
- support `--track`, `--last`, `--json`, `--camera`, and `--redis-url`
- add fakeredis-backed unit tests for listing, single-track filtering, recent-event limiting, JSON payloads, and detailed text rows

Fixes #43

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_inspect_tracks.py tests/test_cross_camera_reid.py -q` ✅ 27 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check scripts/inspect_tracks.py tests/test_inspect_tracks.py` ✅
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m black --check scripts/inspect_tracks.py tests/test_inspect_tracks.py` ✅
- `git diff --check` ✅

## Note
I also ran the full suite with `pytest -q`; it currently fails on pre-existing main-branch issues outside this PR (`tests/test_detector.py` schema/property expectations and a `SyntaxError: 'return' outside function` in `services/tracking/tracker.py`). The new CLI tests and related memory/ReID tests pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Redis-backed CLI to inspect tracks and events with human-readable or JSON output, filter by camera/track, limit to recent events, summarize actions/zones, and redact Redis credentials in output.

* **Tests**
  * Added tests covering listing/filtering tracks, limiting recent events, skipping malformed records, argument validation, JSON payloads, text rendering, and credential redaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Devnil434/Eagle-Real-Time-Semantic-Surveillance-using-Detection-Tracking-Reasoning/pull/57)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->