### PR TITLE
Fix/Add ReasoningResult confidence_tier/is_actionable computed fields + boundary tests

### DIFF
--- a/libs/schemas/reasoning.py
+++ b/libs/schemas/reasoning.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import Literal, Optional
-from pydantic import BaseModel, Field
-import json
+from pydantic import BaseModel, Field, computed_field
 
 
 class ReasoningResult(BaseModel):
@@ -16,25 +15,21 @@ class ReasoningResult(BaseModel):
     severity_score: float                            = Field(0.0, ge=0.0, le=1.0)
     alert_id:       Optional[str]                    = None
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def confidence_tier(self) -> Literal["high", "medium", "low"]:
+        """Classify confidence into high/medium/low tiers for dashboard colour-coding."""
         if self.confidence >= 0.75:
             return "high"
-
         if self.confidence >= 0.50:
             return "medium"
-
         return "low"
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def is_actionable(self) -> bool:
+        """True when the alert warrants operator attention."""
         return self.label == "Suspicious" and self.confidence >= 0.65
-
-    def model_dump_json(self, **kw) -> str:
-        d = self.model_dump(**kw)
-        d["confidence_tier"] = self.confidence_tier
-        d["is_actionable"]   = self.is_actionable
-        return json.dumps(d, default=str)
 
 
 class GroundingResult(BaseModel):

--- a/tests/test_reasoning_schema.py
+++ b/tests/test_reasoning_schema.py
@@ -1,0 +1,106 @@
+"""
+Unit tests for ReasoningResult computed properties:
+  - confidence_tier  (high / medium / low)
+  - is_actionable    (Suspicious AND confidence >= 0.65)
+
+Covers every boundary listed in the acceptance criteria for issue #117.
+"""
+from __future__ import annotations
+
+import json
+import pytest
+
+from libs.schemas.reasoning import ReasoningResult
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make(label: str = "Suspicious", confidence: float = 0.80) -> ReasoningResult:
+    """Return a minimal valid ReasoningResult with the given label/confidence."""
+    return ReasoningResult(
+        track_id=1,
+        label=label,
+        confidence=confidence,
+        reason="test",
+    )
+
+
+# ── confidence_tier tests (6 boundary values) ────────────────────────────────
+
+class TestConfidenceTier:
+
+    def test_confidence_below_050_returns_low(self):
+        """0.49 → low"""
+        assert _make(confidence=0.49).confidence_tier == "low"
+
+    def test_confidence_at_050_returns_medium(self):
+        """0.50 → medium (inclusive lower bound)"""
+        assert _make(confidence=0.50).confidence_tier == "medium"
+
+    def test_confidence_below_075_returns_medium(self):
+        """0.74 → medium (just below high threshold)"""
+        assert _make(confidence=0.74).confidence_tier == "medium"
+
+    def test_confidence_at_075_returns_high(self):
+        """0.75 → high (inclusive lower bound)"""
+        assert _make(confidence=0.75).confidence_tier == "high"
+
+    def test_confidence_at_100_returns_high(self):
+        """1.0 → high (maximum)"""
+        assert _make(confidence=1.0).confidence_tier == "high"
+
+    def test_confidence_at_000_returns_low(self):
+        """0.0 → low (minimum)"""
+        assert _make(confidence=0.0).confidence_tier == "low"
+
+
+# ── is_actionable tests ──────────────────────────────────────────────────────
+
+class TestIsActionable:
+
+    def test_suspicious_high_conf_is_actionable(self):
+        """Suspicious + confidence 0.65 → True"""
+        assert _make(label="Suspicious", confidence=0.65).is_actionable is True
+
+    def test_suspicious_above_threshold_is_actionable(self):
+        """Suspicious + confidence 0.90 → True"""
+        assert _make(label="Suspicious", confidence=0.90).is_actionable is True
+
+    def test_suspicious_below_threshold_not_actionable(self):
+        """Suspicious + confidence 0.64 → False"""
+        assert _make(label="Suspicious", confidence=0.64).is_actionable is False
+
+    def test_normal_high_conf_not_actionable(self):
+        """Normal + high confidence → False (wrong label)"""
+        assert _make(label="Normal", confidence=0.95).is_actionable is False
+
+    def test_normal_low_conf_not_actionable(self):
+        """Normal + low confidence → False"""
+        assert _make(label="Normal", confidence=0.30).is_actionable is False
+
+
+# ── serialisation tests ──────────────────────────────────────────────────────
+
+class TestSerialization:
+
+    def test_model_dump_mode_json_includes_confidence_tier(self):
+        r = _make(confidence=0.80)
+        d = r.model_dump(mode="json")
+        assert d["confidence_tier"] == "high"
+
+    def test_model_dump_mode_json_includes_is_actionable(self):
+        r = _make(label="Suspicious", confidence=0.80)
+        d = r.model_dump(mode="json")
+        assert d["is_actionable"] is True
+
+    def test_model_dump_json_includes_both_properties(self):
+        r = _make(label="Suspicious", confidence=0.51)
+        parsed = json.loads(r.model_dump_json())
+        assert parsed["confidence_tier"] == "medium"
+        assert parsed["is_actionable"] is False
+
+    def test_model_dump_plain_includes_computed_fields(self):
+        r = _make(label="Normal", confidence=0.49)
+        d = r.model_dump()
+        assert d["confidence_tier"] == "low"
+        assert d["is_actionable"] is False


### PR DESCRIPTION
## Summary

Closes #117

Adds two computed properties to `ReasoningResult` so the frontend can colour-code alerts and determine actionability without duplicating threshold logic.

## Changes

### `libs/schemas/reasoning.py`
- **Replaced** `@property` + manual `model_dump_json()` override with Pydantic v2 `@computed_field`
- `confidence_tier` → `"high"` (≥ 0.75), `"medium"` (≥ 0.50), `"low"` (< 0.50)
- `is_actionable` → `True` only when `label == "Suspicious"` **and** `confidence >= 0.65`
- Removed the fragile `model_dump_json` override — `@computed_field` automatically includes both properties in `model_dump()`, `model_dump(mode="json")`, and `model_dump_json()` output

### `tests/test_reasoning_schema.py` (new)
15 unit tests organised into three classes:

| Class | Tests | Coverage |
|---|---|---|
| `TestConfidenceTier` | 6 | Boundaries: 0.0, 0.49, 0.50, 0.74, 0.75, 1.0 |
| `TestIsActionable` | 5 | Suspicious ≥ 0.65 ✓, Suspicious < 0.65 ✗, Normal any conf ✗ |
| `TestSerialization` | 4 | `model_dump()`, `model_dump(mode="json")`, `model_dump_json()` |

## Why `@computed_field` instead of `@property`

The previous implementation used plain `@property` (invisible to Pydantic serialization) plus a manual `model_dump_json()` override that stitched the values into the dict. This approach:
- Didn't work with `model_dump(mode="json")` (the acceptance criteria's requirement)
- Didn't include the fields in the JSON schema
- Was fragile — any caller using `model_dump()` directly would silently miss both fields

`@computed_field` (Pydantic v2) solves all of these. Zero downstream breakage — existing call sites using `model_dump_json()` or `model_dump()` continue to work, now with the computed fields included automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reasoning result now exposes computed fields for confidence tier and actionability and includes them in serialized outputs.

* **Tests**
  * Added comprehensive tests covering confidence-tier boundaries, actionability rules, and inclusion of computed fields in serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->