### PR TITLE
feat: add reasoning_result_id field to TrackEvent #116

### DIFF
--- a/libs/schemas/memory.py
+++ b/libs/schemas/memory.py
@@ -47,6 +47,7 @@ class TrackEvent(BaseModel):
     center:      tuple[float, float] = (0.0, 0.0)
     dwell_time_seconds: float     = 0.0
     confidence:  float            = 0.0
+    reasoning_result_id: Optional[str] = None
 
 
 class TrackSequence(BaseModel):

--- a/services/reasoning/pipeline.py
+++ b/services/reasoning/pipeline.py
@@ -110,6 +110,14 @@ class ReasoningPipeline:
         self._store_alert(result)
         self._deduplicator.mark_alerted(track_id, zone)
 
+        # Back-link the trigger event to the reasoning result (update in place)
+        if seq.events:
+            trigger_event = seq.events[-1]
+            trigger_event.reasoning_result_id = result.alert_id
+            key = self._store._events_key(trigger_event.track_id)
+            payload = trigger_event.model_dump() if hasattr(trigger_event, "model_dump") else trigger_event.dict()
+            self._store._r.lset(key, -1, json.dumps(payload))
+
         # Non-blocking push to SSE queue
         try:
             alert_queue.put_nowait(result)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -390,3 +390,19 @@ def test_near_keypad_hint():
     assert hint == ActionHint.NEAR_KEYPAD
 
 
+# ── reasoning_result_id tests ──────────────────────────────────────────────────
+
+def test_reasoning_result_id_absent_by_default():
+    """reasoning_result_id should default to None when no reasoning has run."""
+    evt = make_event(50, 0)
+    assert evt.reasoning_result_id is None
+
+
+def test_reasoning_result_id_present_after_set(store):
+    """reasoning_result_id should be stored and retrieved correctly."""
+    evt = make_event(51, 0, zone="restricted_door", hint=ActionHint.ZONE_ENTRY)
+    evt.reasoning_result_id = "test-alert-id-123"
+    store.store_event(evt)
+    seq = store.get_sequence(track_id=51)
+    assert seq.events[0].reasoning_result_id == "test-alert-id-123"
+


### PR DESCRIPTION
Closes #116

## What changed
- Added `reasoning_result_id: Optional[str] = None` to `TrackEvent` in `libs/schemas/memory.py`
- Updated `ReasoningPipeline.run()` in `services/reasoning/pipeline.py` to back-link the trigger event to the reasoning result after storing the alert
- Added 2 new tests in `tests/test_memory.py`

## Tests
All 27 tests passing ✅
- `test_reasoning_result_id_absent_by_default` — field defaults to None
- `test_reasoning_result_id_present_after_set` — field is stored and retrieved correctly

## Notes for maintainer
Found two existing bugs while setting up locally:
- `services/detection/zones.py` line 122: wraps already-constructed Zone objects in Zone() again, causing AttributeError
- `services/__init__.py` eagerly imports tracking which causes test collection failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events can now be linked to their corresponding processing results, improving data traceability and relationship visibility.

* **Tests**
  * Added test coverage for event-result linking and persistence behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Devnil434/Eagle/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->