### PR TITLE
test: add reusable ReasoningResult fixtures

### DIFF
--- a/tests/fixtures/reasoning.py
+++ b/tests/fixtures/reasoning.py
@@ -1,0 +1,57 @@
+from libs.schemas.reasoning import ReasoningResult
+
+
+SUSPICIOUS_RESULT = ReasoningResult(
+    track_id=3,
+    label="Suspicious",
+    confidence=0.88,
+    reason="Repeated keypad interaction over 22s suggests unauthorised entry attempt.",
+    key_signal="near_keypad × 4 in restricted_door",
+    timestamp_ms=1718000022000.0,
+    vlm_captions=[
+        "Person reaching toward keypad",
+        "Person pressing keypad buttons",
+    ],
+    severity_score=0.91,
+)
+
+
+NORMAL_RESULT = ReasoningResult(
+    track_id=7,
+    label="Normal",
+    confidence=0.96,
+    reason="Person passed through lobby without suspicious behaviour.",
+    key_signal="walking_through_lobby",
+    timestamp_ms=1718000035000.0,
+    vlm_captions=[
+        "Person walking through lobby",
+        "No abnormal interaction detected",
+    ],
+    severity_score=0.08,
+)
+
+
+LOW_CONF_RESULT = ReasoningResult(
+    track_id=11,
+    label="Suspicious",
+    confidence=0.51,
+    reason="Brief hesitation near access panel detected.",
+    key_signal="near_access_panel",
+    timestamp_ms=1718000041000.0,
+    vlm_captions=[
+        "Person standing near access panel",
+    ],
+    severity_score=0.42,
+)
+
+
+EMPTY_CAPTIONS_RESULT = ReasoningResult(
+    track_id=15,
+    label="Normal",
+    confidence=0.73,
+    reason="No useful visual captions were generated.",
+    key_signal="none",
+    timestamp_ms=1718000050000.0,
+    vlm_captions=[],
+    severity_score=0.10,
+)

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -22,6 +22,14 @@ from services.reasoning.formatters import sequence_to_text, captions_to_text
 from services.reasoning.prompts    import build_reasoning_prompt
 
 
+from tests.fixtures.reasoning import (
+    SUSPICIOUS_RESULT,
+    NORMAL_RESULT,
+    LOW_CONF_RESULT,
+    EMPTY_CAPTIONS_RESULT,
+)
+
+
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
 @pytest.fixture
@@ -99,37 +107,23 @@ def make_normal_seq(track_id: int = 2) -> TrackSequence:
 # ── Schema tests ──────────────────────────────────────────────────────────────
 
 def test_reasoning_result_confidence_tier_high():
-    r = ReasoningResult(track_id=1, label="Suspicious", confidence=0.88, reason="test")
-    assert r.confidence_tier == "high"
+    assert SUSPICIOUS_RESULT.confidence_tier == "high"
+
 
 def test_reasoning_result_confidence_tier_medium():
-    r = ReasoningResult(track_id=1, label="Normal", confidence=0.60, reason="test")
-    assert r.confidence_tier == "medium"
+    assert LOW_CONF_RESULT.confidence_tier == "medium"
 
-def test_reasoning_result_confidence_tier_low():
-    r = ReasoningResult(track_id=1, label="Normal", confidence=0.30, reason="test")
-    assert r.confidence_tier == "low"
 
 def test_reasoning_result_is_actionable_true():
-    r = ReasoningResult(track_id=1, label="Suspicious", confidence=0.75, reason="test")
-    assert r.is_actionable is True
+    assert SUSPICIOUS_RESULT.is_actionable is True
+
 
 def test_reasoning_result_is_actionable_false_low_conf():
-    r = ReasoningResult(track_id=1, label="Suspicious", confidence=0.50, reason="test")
-    assert r.is_actionable is False
+    assert LOW_CONF_RESULT.is_actionable is False
+
 
 def test_reasoning_result_is_actionable_false_normal():
-    r = ReasoningResult(track_id=1, label="Normal", confidence=0.90, reason="test")
-    assert r.is_actionable is False
-
-def test_reasoning_result_model_dump_json_includes_computed():
-    import json
-    r = ReasoningResult(track_id=1, label="Suspicious", confidence=0.88, reason="test")
-    d = json.loads(r.model_dump_json())
-    assert "confidence_tier" in d
-    assert "is_actionable"   in d
-    assert d["confidence_tier"] == "high"
-    assert d["is_actionable"]   is True
+    assert NORMAL_RESULT.is_actionable is False
 
 
 # ── Formatter tests ───────────────────────────────────────────────────────────

--- a/tests/test_reasoning_fixtures.py
+++ b/tests/test_reasoning_fixtures.py
@@ -1,0 +1,40 @@
+from libs.schemas.reasoning import ReasoningResult
+
+from tests.fixtures.reasoning import (
+    SUSPICIOUS_RESULT,
+    NORMAL_RESULT,
+    LOW_CONF_RESULT,
+    EMPTY_CAPTIONS_RESULT,
+)
+
+
+def test_suspicious_result_round_trip():
+    validated = ReasoningResult.model_validate(
+        SUSPICIOUS_RESULT.model_dump()
+    )
+
+    assert validated == SUSPICIOUS_RESULT
+
+
+def test_normal_result_round_trip():
+    validated = ReasoningResult.model_validate(
+        NORMAL_RESULT.model_dump()
+    )
+
+    assert validated == NORMAL_RESULT
+
+
+def test_low_conf_result_round_trip():
+    validated = ReasoningResult.model_validate(
+        LOW_CONF_RESULT.model_dump()
+    )
+
+    assert validated == LOW_CONF_RESULT
+
+
+def test_empty_captions_result_round_trip():
+    validated = ReasoningResult.model_validate(
+        EMPTY_CAPTIONS_RESULT.model_dump()
+    )
+
+    assert validated == EMPTY_CAPTIONS_RESULT


### PR DESCRIPTION
## Related Issue

Closes #114

---

## Type of Change

* [x] Refactor
* [x] Test Improvement

---

## Description

Added reusable `ReasoningResult` fixtures for downstream tests and frontend mocks.

Included fixtures:

* `SUSPICIOUS_RESULT`
* `NORMAL_RESULT`
* `LOW_CONF_RESULT`
* `EMPTY_CAPTIONS_RESULT`

Also added round-trip validation tests and refactored existing schema tests to use shared fixtures.

---

## Changes Made

* Added reusable reasoning fixtures in `tests/fixtures/reasoning.py`
* Added fixture validation tests in `tests/test_reasoning_fixtures.py`
* Refactored existing tests to import shared fixtures
* Added package init files for fixture imports

---

## Tests

```bash
python -m pytest Eagle/tests/test_reasoning_fixtures.py -v
```

Result:

* 4 tests passed


