### PR TITLE
fix(tests): order-agnostic vlm_captions assertions in test_reasoning_fixtures

### DIFF
--- a/tests/test_reasoning_fixtures.py
+++ b/tests/test_reasoning_fixtures.py
@@ -1,3 +1,15 @@
+"""
+Tests for shared ReasoningResult fixtures.
+
+Round-trip tests validate that model_dump() -> model_validate() preserves
+all scalar fields correctly.
+
+vlm_captions is asserted with membership checks (not positional index)
+because model_dump() / future schema migrations do not guarantee list order.
+
+  CORRECT:   assert "Person reaching toward keypad" in result.vlm_captions
+  INCORRECT: assert result.vlm_captions[0] == "Person reaching toward keypad"
+"""
 from libs.schemas.reasoning import ReasoningResult
 
 from tests.fixtures.reasoning import (
@@ -8,12 +20,42 @@ from tests.fixtures.reasoning import (
 )
 
 
+def _assert_scalar_fields_match(original: ReasoningResult, validated: ReasoningResult) -> None:
+    """Compare every field except vlm_captions, which is checked separately."""
+    assert validated.track_id       == original.track_id
+    assert validated.camera_id      == original.camera_id
+    assert validated.label          == original.label
+    assert validated.confidence     == original.confidence
+    assert validated.reason         == original.reason
+    assert validated.key_signal     == original.key_signal
+    assert validated.timestamp_ms   == original.timestamp_ms
+    assert validated.severity_score == original.severity_score
+    assert validated.alert_id       == original.alert_id
+
+
+def _assert_captions_membership(original: ReasoningResult, validated: ReasoningResult) -> None:
+    """
+    Assert that the round-tripped captions contain exactly the same items
+    as the original, without relying on positional order.
+    """
+    assert len(validated.vlm_captions) == len(original.vlm_captions)
+
+    for caption in original.vlm_captions:
+        assert caption in validated.vlm_captions, (
+            f"Caption missing after round-trip: {caption!r}"
+        )
+
+
 def test_suspicious_result_round_trip():
     validated = ReasoningResult.model_validate(
         SUSPICIOUS_RESULT.model_dump()
     )
 
-    assert validated == SUSPICIOUS_RESULT
+    _assert_scalar_fields_match(SUSPICIOUS_RESULT, validated)
+    _assert_captions_membership(SUSPICIOUS_RESULT, validated)
+
+    assert "Person reaching toward keypad"  in validated.vlm_captions
+    assert "Person pressing keypad buttons" in validated.vlm_captions
 
 
 def test_normal_result_round_trip():
@@ -21,7 +63,11 @@ def test_normal_result_round_trip():
         NORMAL_RESULT.model_dump()
     )
 
-    assert validated == NORMAL_RESULT
+    _assert_scalar_fields_match(NORMAL_RESULT, validated)
+    _assert_captions_membership(NORMAL_RESULT, validated)
+
+    assert "Person walking through lobby"     in validated.vlm_captions
+    assert "No abnormal interaction detected" in validated.vlm_captions
 
 
 def test_low_conf_result_round_trip():
@@ -29,7 +75,10 @@ def test_low_conf_result_round_trip():
         LOW_CONF_RESULT.model_dump()
     )
 
-    assert validated == LOW_CONF_RESULT
+    _assert_scalar_fields_match(LOW_CONF_RESULT, validated)
+    _assert_captions_membership(LOW_CONF_RESULT, validated)
+
+    assert "Person standing near access panel" in validated.vlm_captions
 
 
 def test_empty_captions_result_round_trip():
@@ -37,4 +86,6 @@ def test_empty_captions_result_round_trip():
         EMPTY_CAPTIONS_RESULT.model_dump()
     )
 
-    assert validated == EMPTY_CAPTIONS_RESULT
+    _assert_scalar_fields_match(EMPTY_CAPTIONS_RESULT, validated)
+
+    assert validated.vlm_captions == []


### PR DESCRIPTION
Fixes #135

## What was wrong
The old tests used `assert validated == SUSPICIOUS_RESULT` which compares
vlm_captions as a positionally ordered list. If the order ever changes
internally, the test breaks for the wrong reason.

## What I changed
- tests/test_reasoning_fixtures.py only

Replaced `==` equality with:
- _assert_scalar_fields_match() for all non-list fields
- _assert_captions_membership() which checks presence, not position

## Example
CORRECT:   assert "Person reaching toward keypad" in result.vlm_captions
INCORRECT: assert result.vlm_captions[0] == "Person reaching toward keypad"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test verification with more granular assertion checks and order-independent validation for fixture data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->