### PR TITLE
fix: resolve 3 syntax bugs blocking pytest collection

### DIFF
--- a/apps/backend/dependencies.py
+++ b/apps/backend/dependencies.py
@@ -8,7 +8,7 @@ async def get_redis_client() -> aioredis.Redis:
     """Get or create Redis client from REDIS_URL env var."""
     global _redis_client
     if _redis_client is None:
-        redis_url = os.getenv("REDIS_URL", settings.REDIS_URL)
+        redis_url = os.getenv("REDIS_URL", settings.redis_url)
         _redis_client = await aioredis.from_url(redis_url, decode_responses=True)
     return _redis_client
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -11,7 +11,7 @@ from libs.config.settings import settings
 from ultralytics import YOLO  # <-- FIX: Loaded successfully
 
 class PipelineBenchmark:
-    def __init__(self, redis_url=settings.REDIS_URL):
+    def __init__(self, redis_url=settings.redis_url):
         self.redis_url = redis_url
         self.metrics = {
             "detection_times": [],
@@ -314,7 +314,7 @@ if __name__ == "__main__":
     parser.add_argument("--frames", type=int, default=100, help="Number of frames to benchmark")
     args = parser.parse_args()
 
-    REDIS_ENV_URL = os.getenv("REDIS_URL", settings.REDIS_URL)
+    REDIS_ENV_URL = os.getenv("REDIS_URL", settings.redis_url)
     benchrunner = PipelineBenchmark(redis_url=REDIS_ENV_URL)
     
     if args.model:

--- a/scripts/export_finetuning_dataset.py
+++ b/scripts/export_finetuning_dataset.py
@@ -65,7 +65,7 @@ def parse_args():
     
     parser.add_argument(
         "--redis-url",
-        default=os.getenv("REDIS_URL", settings.REDIS_URL),
+        default=os.getenv("REDIS_URL", settings.redis_url),
         help="Redis connection URL (default: env REDIS_URL or localhost:6379)"
     )
     parser.add_argument(

--- a/scripts/inspect_tracks.py
+++ b/scripts/inspect_tracks.py
@@ -21,7 +21,7 @@ from libs.config.settings import settings
 import redis
 
 DEFAULT_CAMERA_ID = "cam_01"
-DEFAULT_REDIS_URL = settings.REDIS_URL
+DEFAULT_REDIS_URL = settings.redis_url
 
 
 @dataclass

--- a/services/tracking/tracker.py
+++ b/services/tracking/tracker.py
@@ -72,16 +72,6 @@ class Tracker:
         reid_similarity_threshold: float = 0.85,
         max_interpolation_gap: int = 10,  # Added with a sensible default
     ) -> None:
-        """Initialize the Tracker with DeepSort backend and internal state.
-
-        Args:
-            fps: Frames per second of the input stream.
-            max_age: Frames before a lost track is marked DEAD.
-            n_init: Frames before a track is CONFIRMED.
-            max_cosine_distance: ReID appearance distance threshold.
-            camera_id: Identifier for the camera feed.
-            event_logger: Optional logger for lifecycle events.
-            reid_similarity_threshold: Cosine similarity cutoff for ReID matching.
         """Initialize the tracker with DeepSort hyperparameters and interpolation constraints.
 
         Args:
@@ -139,7 +129,7 @@ class Tracker:
 
         Args:
             det_frame:  Output of Phase 1 detector (DetectionFrameSchema).
-            raw_frame:  Original BGR frame – needed for appearance features.
+            raw_frame:  Original BGR frame - needed for appearance features.
 
         Returns:
             A ``TrackedFrame`` containing all confirmed tracks for this frame,

--- a/tests/test_inspect_tracks.py
+++ b/tests/test_inspect_tracks.py
@@ -170,7 +170,7 @@ def test_json_payload_is_machine_readable(fake_redis):
 
     encoded = json.dumps(payload)
     decoded = json.loads(encoded)
-    assert decoded["redis_url"] == settings.REDIS_URL
+    assert decoded["redis_url"] == settings.redis_url
     assert "secret" not in encoded
     assert decoded["tracks"][0]["track_id"] == 3
     assert decoded["tracks"][0]["events"][0]["event"] == "BORN"
@@ -184,7 +184,7 @@ def test_text_render_includes_detail_rows_for_single_track(fake_redis):
     output = render_text(
         summaries,
         camera_id="cam_01",
-        redis_url=settings.REDIS_URL,
+        redis_url=settings.redis_url,
         show_event_rows=True,
     )
 


### PR DESCRIPTION
## Summary
- Replace em dash (U+2013) with hyphen in `tracker.py` docstring (SyntaxError)
- Remove duplicate merged `__init__` docstring in `tracker.py` (unterminated string literal)
- Fix `settings.REDIS_URL` → `settings.redis_url` across codebase — pydantic `BaseSettings` normalizes field names to lowercase

## Files Changed
- `services/tracking/tracker.py`
- `scripts/inspect_tracks.py`
- `tests/test_inspect_tracks.py`
- `apps/backend/dependencies.py`
- `benchmark.py`
- `scripts/export_finetuning_dataset.py`

## Test Results
- Before: 0 tests collected (3 collection errors)
- After: 215 tests pass

Closes #149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `max_interpolation_gap` parameter to tracker configuration for enhanced control over trajectory interpolation behavior.

* **Chores**
  * Updated internal Redis configuration handling.
  * Updated test assertions to match configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->