### PR TITLE
fix: ensure metric aliases are always exported

### DIFF
--- a/libs/observability/metrics.py
+++ b/libs/observability/metrics.py
@@ -114,6 +114,6 @@ else:
             "agentic_workflow_duration_seconds"
         ]
 
-        # Backwards-compatible aliases used by API routes
-        INGEST_COUNTER = frames_processed_total
-        REASONING_TRIGGER_COUNTER = reasoning_triggers_total
+# Backwards-compatible aliases used by API routes
+INGEST_COUNTER = frames_processed_total
+REASONING_TRIGGER_COUNTER = reasoning_triggers_total


### PR DESCRIPTION
## Description

This PR fixes a backend startup issue caused by `INGEST_COUNTER` and `REASONING_TRIGGER_COUNTER` not being consistently exported from `libs/observability/metrics.py`.

The aliases were defined inside a nested conditional block, which meant they were not created on all execution paths. As a result, importing these metrics in `apps/backend/routes/ingest.py` could raise:

```text
ImportError: cannot import name 'INGEST_COUNTER' from 'libs.observability.metrics'
```

This prevented the FastAPI backend from starting successfully.

## Changes Made

* Moved the backwards-compatible metric aliases out of the nested conditional block.
* Ensured `INGEST_COUNTER` and `REASONING_TRIGGER_COUNTER` are always available for import.
* Preserved existing metric registration behavior.

## Testing

### Before

```text
ImportError: cannot import name 'INGEST_COUNTER'
```

### After

```text
INFO: Started server process
INFO: Waiting for application startup.
INFO: Application startup complete.
```

### Verification

* Started the backend using:

```bash
uvicorn main:app --reload --port 8000
```

* Confirmed successful startup without import errors.
* Verified Swagger/OpenAPI documentation is accessible at:

```text
http://127.0.0.1:8000/docs
```

## Related Issue

Fixes #156 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of metric counter accessibility across all initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->