### PR TITLE
fix: correct requirements.txt path in Dockerfile.backend closes #169

### DIFF
--- a/infra/docker/Dockerfile.backend
+++ b/infra/docker/Dockerfile.backend
@@ -3,19 +3,8 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Copy requirements from backend app
-COPY apps/backend/requirements.txt ./requirements-backend.txt
-COPY services/reasoning/requirements.txt ./requirements-reasoning.txt
-COPY services/memory/requirements.txt ./requirements-memory.txt
-COPY services/detection/requirements.txt ./requirements-detection.txt
-COPY services/tracking/requirements.txt ./requirements-tracking.txt
-
-# Install all dependencies
-RUN pip install --no-cache-dir \
-    -r requirements-backend.txt \
-    -r requirements-reasoning.txt \
-    -r requirements-memory.txt \
-    -r requirements-detection.txt \
-    -r requirements-tracking.txt
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy everything from context (root)
 COPY . .

--- a/infra/docker/Dockerfile.backend
+++ b/infra/docker/Dockerfile.backend
@@ -3,8 +3,19 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Copy requirements from backend app
-COPY apps/backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY apps/backend/requirements.txt ./requirements-backend.txt
+COPY services/reasoning/requirements.txt ./requirements-reasoning.txt
+COPY services/memory/requirements.txt ./requirements-memory.txt
+COPY services/detection/requirements.txt ./requirements-detection.txt
+COPY services/tracking/requirements.txt ./requirements-tracking.txt
+
+# Install all dependencies
+RUN pip install --no-cache-dir \
+    -r requirements-backend.txt \
+    -r requirements-reasoning.txt \
+    -r requirements-memory.txt \
+    -r requirements-detection.txt \
+    -r requirements-tracking.txt
 
 # Copy everything from context (root)
 COPY . .


### PR DESCRIPTION
## Summary
Fixed and Closes #169

## What changed
- Changed `COPY apps/backend/requirements.txt .` to `COPY requirements.txt .` 
  in `infra/docker/Dockerfile.backend`

## Why
The docker-compose.yml sets build context to `./apps/backend`, so inside 
the Dockerfile the path should be just `requirements.txt`, not 
`apps/backend/requirements.txt`. The wrong path caused the entire 
Docker build to fail.

## Testing
- Ran `docker-compose up -d --build` locally
- Backend image built successfully after this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the backend build process to include dependencies for additional services alongside the main app.
  * The backend image now installs all required Python packages in one step, helping ensure the deployed environment includes everything needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->