### PR TITLE
fix: add required center field to DetectionSchema instantiations in tests (closes #158)

### DIFF
--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -18,7 +18,8 @@ def test_detection_schema_invalid_confidence():
         DetectionSchema(
             label="person",
             confidence=1.5,
-            bbox=BoundingBox(x1=0, y1=0, x2=10, y2=10)
+            bbox=BoundingBox(x1=0, y1=0, x2=10, y2=10),
+            center=(5.0, 5.0)
         )
 
 
@@ -26,7 +27,8 @@ def test_detection_frame_schema_stores_detections():
     det = DetectionSchema(
         label="car",
         confidence=0.9,
-        bbox=BoundingBox(x1=0, y1=0, x2=50, y2=50)
+        bbox=BoundingBox(x1=0, y1=0, x2=50, y2=50),
+        center=(25.0, 25.0)
     )
     frame = DetectionFrameSchema(frame_id=1, detections=[det])
     assert len(frame.detections) == 1


### PR DESCRIPTION
## What
The bug report indicates that `DetectionSchema` requires a `center` field, but the tests do not provide it, causing `ValidationError`. This PR adds the `center` field to all `DetectionSchema` instantiations in the test file to make the tests pass immediately.

## Fix
Added `center` parameter to `DetectionSchema` constructor calls in `test_detection_schema_invalid_confidence` and `test_detection_frame_schema_stores_detections`. The center values are computed from the bounding box midpoints: for bbox (0,0)-(10,10) center is (5,5); for (0,0)-(50,50) center is (25,25).

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated tests to include the required detection details for valid test data.
  * Improved coverage for detection validation and frame storage behavior, while keeping existing stored-results checks unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->