### PR TITLE
feat: add AI-generated incident summary reports (#182)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,5 +43,13 @@ ALERT_DEDUP_WINDOW=300
 API_HOST=0.0.0.0
 API_PORT=8000
 
+# ── Incident summary reports ─────────────────────────────────────────────
+# Window applied by GET /reports/summary when start/end are omitted.
+REPORT_DEFAULT_WINDOW_HOURS=24
+# Largest window a single report may span, rejected with 422 beyond this.
+REPORT_MAX_WINDOW_HOURS=744
+# Upper bound on alerts loaded per report; reports flag when it is reached.
+REPORT_MAX_ALERTS=5000
+
 # ── Policy ───────────────────────────────────────────────────────────────
 POLICY_PATH=policies/default.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 eagle_surveillance.egg-info/
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -309,6 +309,34 @@ Human-in-the-loop endpoint to mark an alert as correct or incorrect.
 Request: { "alert_id": "alert_001", "correct": false, "note": "Normal employee" }
 ```
 
+### `GET /reports/summary`
+Incident summary report for a time window: event timeline, object and zone
+breakdowns, ranked suspicious activities, and aggregate confidence statistics.
+Reports reuse the reasoning text stored with each alert, so generating one costs
+no model inference.
+
+| Query param | Default | Meaning |
+|---|---|---|
+| `start` | `end` − 24h | ISO-8601 start of the window (naive values read as UTC) |
+| `end` | now | ISO-8601 end of the window |
+| `camera_id` | all cameras | Restrict the report to one camera |
+| `format` | `markdown` | `markdown`, `json`, or `pdf` |
+| `top_n` | `10` | Suspicious activities to spotlight |
+| `include_dismissed` | `true` | Include alerts an operator dismissed |
+| `download` | `false` | Serve as a file attachment |
+
+```bash
+# Markdown report for the last 24 hours
+curl "http://localhost:8000/reports/summary"
+
+# PDF export for one camera and a specific window
+curl -o incident.pdf "http://localhost:8000/reports/summary?\
+start=2026-06-15T08:00:00Z&end=2026-06-15T18:00:00Z&camera_id=cam_01&format=pdf&download=true"
+```
+
+Alerts written before zone and object provenance were recorded are grouped under
+`unknown` rather than dropped.
+
 ---
 
 ## 🗺️ Roadmap

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -8,6 +8,9 @@ httpx==0.27.0
 sse-starlette==2.1.0
 prometheus-client==0.20.0
 python-multipart>=0.0.30    # file uploads for /snapshot
+jinja2==3.1.6              # incident summary report templates (3.1.6 fixes CVE-2025-27516)
+markdown==3.10.3           # markdown → HTML for PDF export
+fpdf2==2.8.8               # PDF export (pure Python, no system libraries)
 fakeredis==2.21.3          # tests
 pytest==8.1.1
 pytest-asyncio==0.23.6

--- a/apps/backend/routes/reports.py
+++ b/apps/backend/routes/reports.py
@@ -1,0 +1,171 @@
+"""
+GET /reports/summary — AI-generated incident summary for a time window.
+
+Aggregates the alerts already produced by the reasoning layer, so a report costs
+no model inference and cannot fail on a provider outage: the natural-language
+assessments are the ones written when each alert fired.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+
+from apps.backend.deps import get_store
+from libs.config.settings import settings
+from libs.schemas.reasoning import ReasoningResult
+from services.memory.ring_buffer import MemoryStore
+from services.reporting import (
+    ReportFormat,
+    ReportRenderError,
+    TimeWindow,
+    build_summary,
+    get_renderer,
+)
+
+logger = logging.getLogger("eagle.reports")
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+
+@router.get(
+    "/summary",
+    summary="Incident summary report for a time window",
+    response_class=Response,
+    responses={
+        200: {
+            "content": {
+                "text/markdown": {},
+                "application/json": {},
+                "application/pdf": {},
+            },
+            "description": "Rendered incident summary.",
+        },
+        422: {"description": "Invalid or excessive time window."},
+        503: {"description": "Requested format unavailable in this deployment."},
+    },
+)
+def summary_report(
+    start: Optional[datetime] = Query(
+        None,
+        description="ISO-8601 start of the window. Defaults to "
+                    "`end` minus `report_default_window_hours`.",
+    ),
+    end: Optional[datetime] = Query(
+        None, description="ISO-8601 end of the window. Defaults to now."
+    ),
+    camera_id: Optional[str] = Query(
+        None, description="Restrict to one camera. Omit to cover all cameras."
+    ),
+    report_format: ReportFormat = Query(
+        "markdown", alias="format", description="Output format."
+    ),
+    top_n: int = Query(
+        10, ge=1, le=100, description="How many suspicious activities to spotlight."
+    ),
+    include_dismissed: bool = Query(
+        True, description="Include alerts an operator dismissed."
+    ),
+    download: bool = Query(
+        False, description="Serve as a file attachment rather than inline."
+    ),
+    store: MemoryStore = Depends(get_store),
+) -> Response:
+    """Summarise detected activity between `start` and `end`."""
+    window = _resolve_window(start, end)
+
+    raw_alerts = store.get_alerts_in_range(
+        start_ms  = window.start_ms,
+        end_ms    = window.end_ms,
+        camera_id = camera_id,
+        limit     = settings.report_max_alerts,
+    )
+    alerts = [parsed for raw in raw_alerts if (parsed := _parse_alert(raw))]
+
+    verdicts = store.get_feedback_bulk([a.alert_id for a in alerts if a.alert_id])
+    if not include_dismissed:
+        alerts = [a for a in alerts if verdicts.get(a.alert_id or "") != "dismissed"]
+
+    summary = build_summary(
+        alerts,
+        window,
+        feedback        = verdicts,
+        top_n           = top_n,
+        truncated       = len(raw_alerts) >= settings.report_max_alerts,
+        generated_at_ms = time.time() * 1000,
+    )
+
+    try:
+        renderer = get_renderer(report_format)
+        body = renderer.render(summary)
+    except ReportRenderError as exc:
+        logger.warning("Report rendering failed (format=%s): %s", report_format, exc)
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    logger.info(
+        "Report generated  format=%s  camera=%s  alerts=%d  truncated=%s",
+        report_format, camera_id or "all", summary.total_alerts, summary.truncated,
+    )
+    return Response(
+        content=body,
+        media_type=renderer.media_type,
+        headers=_content_disposition(window, renderer.extension, download),
+    )
+
+
+def _resolve_window(start: Optional[datetime], end: Optional[datetime]) -> TimeWindow:
+    """Apply defaults, then validate ordering and span.
+
+    Naive datetimes are read as UTC, matching the epoch-millisecond timestamps
+    the reasoning layer writes.
+    """
+    end = end or datetime.now(tz=timezone.utc)
+    start = start or end - timedelta(hours=settings.report_default_window_hours)
+
+    start, end = _as_utc(start), _as_utc(end)
+
+    if start >= end:
+        raise HTTPException(
+            status_code=422, detail="`start` must be strictly earlier than `end`."
+        )
+
+    max_span = timedelta(hours=settings.report_max_window_hours)
+    if end - start > max_span:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Window exceeds the {settings.report_max_window_hours:g}h maximum. "
+                   "Request a narrower range.",
+        )
+
+    return TimeWindow(start_ms=start.timestamp() * 1000, end_ms=end.timestamp() * 1000)
+
+
+def _as_utc(moment: datetime) -> datetime:
+    return moment.replace(tzinfo=timezone.utc) if moment.tzinfo is None else moment
+
+
+def _parse_alert(raw: str) -> Optional[ReasoningResult]:
+    """Deserialise a stored alert, skipping any record we cannot read.
+
+    A single corrupt entry must not deny the operator the rest of the report.
+    """
+    try:
+        return ReasoningResult(**json.loads(raw))
+    except Exception as exc:
+        logger.warning("Skipping unreadable alert in report window: %s", exc)
+        return None
+
+
+def _content_disposition(
+    window: TimeWindow, extension: str, download: bool
+) -> dict[str, str]:
+    stamp = datetime.fromtimestamp(
+        window.start_ms / 1000, tz=timezone.utc
+    ).strftime("%Y%m%dT%H%M%SZ")
+    disposition = "attachment" if download else "inline"
+    filename = f"eagle-incident-summary-{stamp}.{extension}"
+    return {"Content-Disposition": f'{disposition}; filename="{filename}"'}

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -32,6 +32,9 @@ class AlertResponse(BaseModel):
     timestamp_ms:  float
     vlm_captions:  list[str] = Field(default_factory=list)
     feedback:      Optional[str] = None    # "confirmed" | "dismissed" | None
+    zone:          Optional[str] = None    # None on alerts predating provenance capture
+    zones_visited: list[str] = Field(default_factory=list)
+    object_labels: list[str] = Field(default_factory=list)
 
 class FeedbackRequest(BaseModel):
     operator_id: str = "anonymous"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,7 @@ Eagle is an event-driven surveillance reasoning pipeline that converts raw video
 | Temporal Memory | Redis Ring Buffer | `track_id + event payload` | Sliding event history (`last_n_events`) |
 | VLM Captioning | LLaVA-Next / Qwen-VL | Triggered frame sequence | Natural language captions |
 | LLM Reasoning | Mixtral / GPT-4o / Gemini | Caption sequence + policies | `Alert(label, confidence, reason)` |
+| Incident Reporting | Jinja2 + fpdf2 | Stored alerts for a time window | `IncidentSummary` as Markdown / JSON / PDF |
 | Backend API | FastAPI + Celery | REST requests | JSON API responses |
 | Frontend | React 19 + Vite | SSE / REST payloads | Live dashboard + alert timeline |
 
@@ -39,3 +40,7 @@ F --> G[LLM Reasoning<br/>services/reasoning/llm.py]
 G --> H[FastAPI Backend<br/>apps/backend/main.py]
 
 H --> I[React Dashboard<br/>apps/dashboard]
+
+H --> J[Incident Reporting<br/>services/reporting]
+
+J -->|Markdown / JSON / PDF| K[Operator Review]

--- a/libs/config/settings.py
+++ b/libs/config/settings.py
@@ -57,6 +57,11 @@ class Settings(BaseSettings):
     max_alerts_page: int = 50
     snapshot_dir: str = "/tmp/eagle_snapshots"
 
+    # ── Incident summary reports ──────────────────────────────────────────
+    report_default_window_hours: float = 24.0
+    report_max_window_hours: float = 24.0 * 31
+    report_max_alerts: int = 5_000
+
     # ── Policy ────────────────────────────────────────────────────────────
     policy_path: str = "policies/default.yaml"
     camera_id: str = "cam_01"

--- a/libs/schemas/reasoning.py
+++ b/libs/schemas/reasoning.py
@@ -15,6 +15,13 @@ class ReasoningResult(BaseModel):
     severity_score: float                            = Field(0.0, ge=0.0, le=1.0)
     alert_id:       Optional[str]                    = None
 
+    # Provenance captured at alert time so downstream consumers (e.g. summary
+    # reports) never have to re-read the ring buffer, which trims to the last
+    # N events per track and expires after `track_ttl_seconds`.
+    zone:           Optional[str]                    = None
+    zones_visited:  list[str]                        = Field(default_factory=list)
+    object_labels:  list[str]                        = Field(default_factory=list)
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def confidence_tier(self) -> Literal["high", "medium", "low"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "pyyaml>=6.0",
     "python-dotenv>=1.0.0",
     "prometheus-client>=0.19.0",
+    "jinja2>=3.1.6",
+    "markdown>=3.7",
+    "fpdf2>=2.8.0",
 ]
 
 [project.optional-dependencies]

--- a/services/memory/ring_buffer.py
+++ b/services/memory/ring_buffer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+import heapq
 import json
+from itertools import islice
 from typing import Optional
 
 from libs.schemas.memory import TrackEvent, TrackSequence
@@ -81,18 +83,26 @@ class MemoryStore:
 
         keys = [f"alerts:{camera_id}"] if camera_id else self._alert_keys()
 
+        # Redis returns each camera's slice pre-sorted by score, so merging keeps
+        # the timeline chronological across cameras.  Trimming to `limit` after
+        # each merge holds the accumulator at `limit` however many cameras exist,
+        # instead of letting it grow to `limit x cameras` before a final cut.
+        # The result is unchanged: the earliest `limit` alerts overall can only
+        # come from the earliest `limit` of each camera.
         scored: list[tuple[float, str]] = []
         for key in keys:
             items = self._r.zrangebyscore(
                 key, start_ms, end_ms, start=0, num=limit, withscores=True
             )
-            for raw, score in items:
-                scored.append((score, raw if isinstance(raw, str) else raw.decode()))
+            batch = [
+                (score, raw if isinstance(raw, str) else raw.decode())
+                for raw, score in items
+            ]
+            scored = list(
+                islice(heapq.merge(scored, batch, key=lambda pair: pair[0]), limit)
+            )
 
-        # Redis returns each camera's slice pre-sorted; merging several requires
-        # a re-sort so the timeline stays chronological across cameras.
-        scored.sort(key=lambda pair: pair[0])
-        return [raw for _, raw in scored[:limit]]
+        return [raw for _, raw in scored]
 
     def _alert_keys(self) -> list[str]:
         """Discover per-camera alert keys via SCAN (never KEYS, which blocks)."""

--- a/services/memory/ring_buffer.py
+++ b/services/memory/ring_buffer.py
@@ -60,6 +60,47 @@ class MemoryStore:
         items = self._r.zrevrange(key, 0, limit - 1)
         return [i if isinstance(i, str) else i.decode() for i in items]
 
+    def get_alerts_in_range(
+        self,
+        start_ms: float,
+        end_ms: float,
+        camera_id: Optional[str] = None,
+        limit: int = 5_000,
+    ) -> list[str]:
+        """Return raw alert JSON for the window [start_ms, end_ms], oldest first.
+
+        Args:
+            start_ms:  Inclusive lower bound (epoch milliseconds).
+            end_ms:    Inclusive upper bound (epoch milliseconds).
+            camera_id: Restrict to one camera; None aggregates every camera.
+            limit:     Hard cap on returned alerts, protecting the caller from
+                       loading an unbounded window into memory.
+        """
+        if start_ms > end_ms or limit <= 0:
+            return []
+
+        keys = [f"alerts:{camera_id}"] if camera_id else self._alert_keys()
+
+        scored: list[tuple[float, str]] = []
+        for key in keys:
+            items = self._r.zrangebyscore(
+                key, start_ms, end_ms, start=0, num=limit, withscores=True
+            )
+            for raw, score in items:
+                scored.append((score, raw if isinstance(raw, str) else raw.decode()))
+
+        # Redis returns each camera's slice pre-sorted; merging several requires
+        # a re-sort so the timeline stays chronological across cameras.
+        scored.sort(key=lambda pair: pair[0])
+        return [raw for _, raw in scored[:limit]]
+
+    def _alert_keys(self) -> list[str]:
+        """Discover per-camera alert keys via SCAN (never KEYS, which blocks)."""
+        keys = []
+        for key in self._r.scan_iter(match="alerts:*"):
+            keys.append(key if isinstance(key, str) else key.decode())
+        return keys
+
     def get_alert_by_id(self, alert_id: str) -> Optional[str]:
         """Return the raw alert JSON for a given alert_id or None."""
         # Scan recent alerts across camera sets — simple linear search
@@ -93,3 +134,26 @@ class MemoryStore:
             return None
         verdict = self._r.hget(key, "verdict")
         return verdict if isinstance(verdict, str) else (verdict.decode() if verdict else None)
+
+    def get_feedback_bulk(self, alert_ids: list[str]) -> dict[str, str]:
+        """Fetch verdicts for many alerts in a single round-trip.
+
+        Reports resolve feedback for every alert in the window, so the per-alert
+        `get_feedback` would cost one round-trip each.  Alerts without feedback
+        are omitted from the result.
+        """
+        if not alert_ids:
+            return {}
+
+        pipe = self._r.pipeline()
+        for alert_id in alert_ids:
+            pipe.hget(f"feedback:{alert_id}", "verdict")
+        verdicts = pipe.execute()
+
+        resolved: dict[str, str] = {}
+        for alert_id, verdict in zip(alert_ids, verdicts):
+            if verdict:
+                resolved[alert_id] = (
+                    verdict if isinstance(verdict, str) else verdict.decode()
+                )
+        return resolved

--- a/services/reasoning/pipeline.py
+++ b/services/reasoning/pipeline.py
@@ -110,7 +110,7 @@ class ReasoningPipeline:
         captions = self._collect_captions(frame, seq, detections)
         result   = self._reasoner.reason(seq, captions)
         result   = self._attach_severity(result, seq)
-        result   = self._attach_provenance(result, seq, zone, detections)
+        result   = self._attach_provenance(result, seq, detections)
         result.alert_id   = str(uuid.uuid4())
         result.timestamp_ms = time.time() * 1000
 
@@ -244,16 +244,19 @@ class ReasoningPipeline:
     def _attach_provenance(
         result:     ReasoningResult,
         seq:        TrackSequence,
-        zone:       str,
         detections: Optional[list[str]],
     ) -> ReasoningResult:
         """Record the zone and detected object classes on the alert itself.
 
-        `zone` mirrors the dedup key, so an alert always reports the zone it was
-        suppressed against.  "unknown" is normalised to None to keep the absent
-        case identical to alerts written before these fields existed.
+        `zone` is the most recent zone the track occupied, which is where the
+        behaviour being reported happened — a track that crossed a corridor into
+        a restricted door is an incident at the door, not the corridor.  The full
+        path stays available in `zones_visited`, and dedup still keys off the
+        first zone so suppression behaviour is unaffected.  A track that visited
+        no zone leaves this None, matching alerts written before these fields
+        existed.
         """
-        result.zone          = zone if zone != "unknown" else None
+        result.zone          = seq.zones_visited[-1] if seq.zones_visited else None
         result.zones_visited = _dedupe(seq.zones_visited)
         result.object_labels = _dedupe(detections or [])
         return result

--- a/services/reasoning/pipeline.py
+++ b/services/reasoning/pipeline.py
@@ -48,6 +48,11 @@ _W = dict(
 )
 
 
+def _dedupe(values: list[str]) -> list[str]:
+    """Order-preserving de-duplication."""
+    return list(dict.fromkeys(v for v in values if v))
+
+
 class ReasoningPipeline:
     """
     Orchestrates VLM + grounding + LLM for one track/frame pair.
@@ -105,6 +110,7 @@ class ReasoningPipeline:
         captions = self._collect_captions(frame, seq, detections)
         result   = self._reasoner.reason(seq, captions)
         result   = self._attach_severity(result, seq)
+        result   = self._attach_provenance(result, seq, zone, detections)
         result.alert_id   = str(uuid.uuid4())
         result.timestamp_ms = time.time() * 1000
 
@@ -230,6 +236,26 @@ class ReasoningPipeline:
         if result.confidence_tier == "high":
             score += _W["high_tier_bonus"]
         result.severity_score = round(min(score, 1.0), 3)
+        return result
+
+    # ── Provenance ────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _attach_provenance(
+        result:     ReasoningResult,
+        seq:        TrackSequence,
+        zone:       str,
+        detections: Optional[list[str]],
+    ) -> ReasoningResult:
+        """Record the zone and detected object classes on the alert itself.
+
+        `zone` mirrors the dedup key, so an alert always reports the zone it was
+        suppressed against.  "unknown" is normalised to None to keep the absent
+        case identical to alerts written before these fields existed.
+        """
+        result.zone          = zone if zone != "unknown" else None
+        result.zones_visited = _dedupe(seq.zones_visited)
+        result.object_labels = _dedupe(detections or [])
         return result
 
     # ── Storage ───────────────────────────────────────────────────────────────

--- a/services/reporting/__init__.py
+++ b/services/reporting/__init__.py
@@ -1,0 +1,43 @@
+"""
+Incident summary reporting.
+
+Turns stored alerts from a time window into an operator-facing report. The layer
+is split so each piece has one reason to change:
+
+    models      — the data contract shared by aggregation and rendering
+    aggregator  — pure statistics, no I/O
+    renderers   — output formats (Markdown, JSON, PDF) behind one Protocol
+    templates   — the single definition of report content
+
+Reports reuse the reason text the reasoning layer already produced, so
+generating one costs no model inference.
+"""
+from services.reporting.aggregator import build_summary
+from services.reporting.models import (
+    ConfidenceStats,
+    GroupStat,
+    IncidentSummary,
+    TimelineEntry,
+    TimeWindow,
+)
+from services.reporting.renderers import (
+    SUPPORTED_FORMATS,
+    ReportFormat,
+    ReportRenderError,
+    ReportRenderer,
+    get_renderer,
+)
+
+__all__ = [
+    "build_summary",
+    "ConfidenceStats",
+    "GroupStat",
+    "IncidentSummary",
+    "TimelineEntry",
+    "TimeWindow",
+    "get_renderer",
+    "ReportFormat",
+    "ReportRenderer",
+    "ReportRenderError",
+    "SUPPORTED_FORMATS",
+]

--- a/services/reporting/aggregator.py
+++ b/services/reporting/aggregator.py
@@ -1,0 +1,143 @@
+"""
+Aggregation of stored alerts into an IncidentSummary.
+
+Deliberately pure: no Redis, no HTTP, no templates, no clock.  Everything the
+result depends on arrives as an argument, which keeps the statistics unit
+testable and makes the summary reproducible for a given window.
+"""
+from __future__ import annotations
+
+import statistics
+from collections import defaultdict
+from typing import Mapping, Optional, Sequence
+
+from libs.schemas.reasoning import ReasoningResult
+from services.reporting.models import (
+    UNKNOWN_GROUP,
+    ConfidenceStats,
+    GroupStat,
+    IncidentSummary,
+    TimelineEntry,
+    TimeWindow,
+)
+
+
+def build_summary(
+    alerts: Sequence[ReasoningResult],
+    window: TimeWindow,
+    *,
+    feedback: Optional[Mapping[str, str]] = None,
+    top_n: int = 10,
+    truncated: bool = False,
+    generated_at_ms: float = 0.0,
+) -> IncidentSummary:
+    """Roll a window of alerts up into a renderable summary.
+
+    Args:
+        alerts:          Alerts inside `window`, in any order.
+        window:          The reported time window.
+        feedback:        alert_id → operator verdict, for alerts that have one.
+        top_n:           How many of the most severe suspicious alerts to spotlight.
+        truncated:       True when the window held more alerts than were fetched.
+        generated_at_ms: Report generation time, injected so output is deterministic.
+    """
+    verdicts = feedback or {}
+    entries = sorted(
+        (_to_timeline_entry(alert, verdicts) for alert in alerts),
+        key=lambda entry: entry.timestamp_ms,
+    )
+
+    suspicious = [e for e in entries if e.label == "Suspicious"]
+
+    return IncidentSummary(
+        generated_at_ms   = generated_at_ms,
+        window            = window,
+        cameras           = sorted({e.camera_id for e in entries}),
+        total_alerts      = len(entries),
+        suspicious_alerts = len(suspicious),
+        normal_alerts     = len(entries) - len(suspicious),
+        actionable_alerts = sum(1 for a in alerts if a.is_actionable),
+        confidence        = _confidence_stats(alerts),
+        by_object_type    = _group_by_object_type(entries),
+        by_zone           = _group_by_zone(entries),
+        top_suspicious    = sorted(
+            suspicious, key=lambda e: (-e.severity_score, -e.confidence)
+        )[:top_n],
+        timeline          = entries,
+        truncated         = truncated,
+    )
+
+
+def _to_timeline_entry(
+    alert: ReasoningResult, verdicts: Mapping[str, str]
+) -> TimelineEntry:
+    alert_id = alert.alert_id or ""
+    return TimelineEntry(
+        timestamp_ms   = alert.timestamp_ms,
+        alert_id       = alert_id,
+        track_id       = alert.track_id,
+        camera_id      = alert.camera_id,
+        label          = alert.label,
+        zone           = alert.zone,
+        object_labels  = list(alert.object_labels),
+        confidence     = alert.confidence,
+        severity_score = alert.severity_score,
+        reason         = alert.reason,
+        key_signal     = alert.key_signal,
+        feedback       = verdicts.get(alert_id),
+    )
+
+
+def _confidence_stats(alerts: Sequence[ReasoningResult]) -> ConfidenceStats:
+    if not alerts:
+        return ConfidenceStats()
+
+    values = [a.confidence for a in alerts]
+    tiers = [a.confidence_tier for a in alerts]
+
+    return ConfidenceStats(
+        mean    = round(statistics.fmean(values), 4),
+        median  = round(statistics.median(values), 4),
+        minimum = round(min(values), 4),
+        maximum = round(max(values), 4),
+        stdev   = round(statistics.stdev(values), 4) if len(values) > 1 else None,
+        high_tier_count   = tiers.count("high"),
+        medium_tier_count = tiers.count("medium"),
+        low_tier_count    = tiers.count("low"),
+    )
+
+
+def _group_by_object_type(entries: Sequence[TimelineEntry]) -> list[GroupStat]:
+    """Group by detected object class.
+
+    An alert carrying several classes contributes to each of them, so group
+    counts can legitimately sum to more than the total alert count.
+    """
+    buckets: dict[str, list[TimelineEntry]] = defaultdict(list)
+    for entry in entries:
+        for label in entry.object_labels or [UNKNOWN_GROUP]:
+            buckets[label].append(entry)
+    return _to_sorted_stats(buckets)
+
+
+def _group_by_zone(entries: Sequence[TimelineEntry]) -> list[GroupStat]:
+    buckets: dict[str, list[TimelineEntry]] = defaultdict(list)
+    for entry in entries:
+        buckets[entry.zone or UNKNOWN_GROUP].append(entry)
+    return _to_sorted_stats(buckets)
+
+
+def _to_sorted_stats(buckets: Mapping[str, list[TimelineEntry]]) -> list[GroupStat]:
+    stats = [
+        GroupStat(
+            key              = key,
+            count            = len(group),
+            suspicious_count = sum(1 for e in group if e.label == "Suspicious"),
+            mean_confidence  = round(statistics.fmean(e.confidence for e in group), 4),
+            max_confidence   = round(max(e.confidence for e in group), 4),
+            mean_severity    = round(statistics.fmean(e.severity_score for e in group), 4),
+        )
+        for key, group in buckets.items()
+    ]
+    # Busiest group first; key breaks ties so output is stable across runs.
+    return sorted(stats, key=lambda s: (-s.count, s.key))

--- a/services/reporting/models.py
+++ b/services/reporting/models.py
@@ -1,0 +1,90 @@
+"""
+Data contract for incident summary reports.
+
+These models are the single interface between aggregation and rendering: the
+aggregator is the only thing that builds them, and every renderer consumes them.
+Adding an output format therefore requires no change here.
+"""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+UNKNOWN_GROUP = "unknown"
+
+
+class TimeWindow(BaseModel):
+    """Inclusive reporting window in epoch milliseconds."""
+
+    start_ms: float
+    end_ms:   float
+
+    @property
+    def duration_seconds(self) -> float:
+        return max(0.0, (self.end_ms - self.start_ms) / 1000)
+
+
+class ConfidenceStats(BaseModel):
+    """Aggregate confidence distribution across the reported alerts."""
+
+    mean:    float = 0.0
+    median:  float = 0.0
+    minimum: float = 0.0
+    maximum: float = 0.0
+    # None for fewer than two samples, where standard deviation is undefined.
+    stdev:   Optional[float] = None
+    high_tier_count:   int = 0
+    medium_tier_count: int = 0
+    low_tier_count:    int = 0
+
+
+class GroupStat(BaseModel):
+    """Rolled-up statistics for one object type or one zone."""
+
+    key:              str
+    count:            int   = 0
+    suspicious_count: int   = 0
+    mean_confidence:  float = 0.0
+    max_confidence:   float = 0.0
+    mean_severity:    float = 0.0
+
+
+class TimelineEntry(BaseModel):
+    """One alert as it appears in the report timeline."""
+
+    timestamp_ms:   float
+    alert_id:       str
+    track_id:       int
+    camera_id:      str
+    label:          Literal["Suspicious", "Normal"]
+    zone:           Optional[str] = None
+    object_labels:  list[str]     = Field(default_factory=list)
+    confidence:     float         = 0.0
+    severity_score: float         = 0.0
+    reason:         str           = ""
+    key_signal:     str           = ""
+    feedback:       Optional[str] = None
+
+
+class IncidentSummary(BaseModel):
+    """Everything a rendered incident report needs, in presentation order."""
+
+    generated_at_ms: float
+    window:          TimeWindow
+    cameras:         list[str] = Field(default_factory=list)
+
+    total_alerts:      int = 0
+    suspicious_alerts: int = 0
+    normal_alerts:     int = 0
+    actionable_alerts: int = 0
+
+    confidence:     ConfidenceStats = Field(default_factory=ConfidenceStats)
+    by_object_type: list[GroupStat]  = Field(default_factory=list)
+    by_zone:        list[GroupStat]  = Field(default_factory=list)
+    top_suspicious: list[TimelineEntry] = Field(default_factory=list)
+    timeline:       list[TimelineEntry] = Field(default_factory=list)
+
+    # True when the window held more alerts than the configured cap, meaning the
+    # report describes a prefix of the window rather than all of it.
+    truncated: bool = False

--- a/services/reporting/renderers.py
+++ b/services/reporting/renderers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import re
 from datetime import datetime, timezone
 from functools import lru_cache
+from html import escape
 from pathlib import Path
 from typing import Literal, Protocol, get_args
 
@@ -84,9 +85,17 @@ def _format_duration(seconds: float) -> str:
 
 
 def _oneline(text: str) -> str:
-    """Make free text safe for a single Markdown table cell."""
-    collapsed = re.sub(r"\s+", " ", text or "").strip()
-    return collapsed.replace("|", "\\|")
+    """Collapse untrusted text to one inert line of Markdown.
+
+    Report text is model-generated (`reason`, `key_signal`) or client-supplied
+    (`camera_id`), so it can contain anything.  A newline or a `|` would break out
+    of a table row, and an HTML-looking fragment survives Markdown conversion
+    intact — `<img ...>` inside a cell makes fpdf2 raise, failing the whole PDF
+    export.  Escaping the HTML metacharacters keeps such text visible as written
+    while leaving nothing for a downstream renderer to interpret.
+    """
+    collapsed = re.sub(r"\s+", " ", str(text or "")).strip()
+    return escape(collapsed, quote=False).replace("|", "\\|")
 
 
 # ── Renderers ─────────────────────────────────────────────────────────────────

--- a/services/reporting/renderers.py
+++ b/services/reporting/renderers.py
@@ -1,0 +1,219 @@
+"""
+Output formats for incident summary reports.
+
+Each renderer turns an `IncidentSummary` into bytes plus the media type to serve
+it as.  Formats are looked up through `get_renderer`, so supporting a new one
+means adding a class and a registry entry — no existing renderer or the route
+itself needs to change.
+
+The PDF renderer intentionally reuses the Markdown renderer's output rather than
+owning a second template, keeping one definition of report content.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Literal, Protocol, get_args
+
+from services.reporting.models import IncidentSummary
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+SUMMARY_TEMPLATE = "summary.md.j2"
+
+# Single source of truth for the formats on offer: the API route annotates its
+# query parameter with this type, so validation and the registry cannot drift.
+ReportFormat = Literal["markdown", "json", "pdf"]
+
+# fpdf2's built-in fonts are latin-1 only, while VLM/LLM text and the template
+# both use typographic characters.  Transliterate the common ones instead of
+# dropping them, so a PDF stays readable.
+_LATIN1_SUBSTITUTIONS = {
+    "\u2192": "->",   # →
+    "\u00d7": "x",    # ×
+    "\u2014": "-",    # —
+    "\u2013": "-",    # –
+    "\u2018": "'",
+    "\u2019": "'",
+    "\u201c": '"',
+    "\u201d": '"',
+    "\u2026": "...",
+    "\u00a0": " ",
+}
+
+
+class ReportRenderError(RuntimeError):
+    """Raised when a format cannot be produced in this environment."""
+
+
+class ReportRenderer(Protocol):
+    """Renders a summary into transferable bytes."""
+
+    media_type: str
+    extension: str
+
+    def render(self, summary: IncidentSummary) -> bytes:
+        ...
+
+
+# ── Jinja filters ─────────────────────────────────────────────────────────────
+
+def _format_timestamp(timestamp_ms: float) -> str:
+    if not timestamp_ms:
+        return "n/a"
+    moment = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
+    return moment.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _format_percent(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"
+
+
+def _format_duration(seconds: float) -> str:
+    total = int(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
+def _oneline(text: str) -> str:
+    """Make free text safe for a single Markdown table cell."""
+    collapsed = re.sub(r"\s+", " ", text or "").strip()
+    return collapsed.replace("|", "\\|")
+
+
+# ── Renderers ─────────────────────────────────────────────────────────────────
+
+class JsonRenderer:
+    """Machine-readable output, for dashboards and downstream tooling."""
+
+    media_type = "application/json"
+    extension = "json"
+
+    def render(self, summary: IncidentSummary) -> bytes:
+        return summary.model_dump_json(indent=2).encode("utf-8")
+
+
+class MarkdownRenderer:
+    """Human-readable report rendered from the Jinja2 template."""
+
+    media_type = "text/markdown; charset=utf-8"
+    extension = "md"
+
+    def render(self, summary: IncidentSummary) -> bytes:
+        return self.render_text(summary).encode("utf-8")
+
+    def render_text(self, summary: IncidentSummary) -> str:
+        template = _template_environment().get_template(SUMMARY_TEMPLATE)
+        # Jinja keeps a trailing newline per block; collapse the runs of blank
+        # lines that leaves so the Markdown reads cleanly.
+        rendered = template.render(s=summary)
+        return re.sub(r"\n{3,}", "\n\n", rendered).strip() + "\n"
+
+
+@lru_cache(maxsize=1)
+def _template_environment():
+    """Build the Jinja environment once; templates are parsed per process."""
+    try:
+        from jinja2 import Environment, FileSystemLoader
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise ReportRenderError(
+            "Jinja2 is required for Markdown reports. Install it with "
+            "`pip install jinja2`."
+        ) from exc
+
+    env = Environment(
+        loader=FileSystemLoader(str(TEMPLATE_DIR)),
+        # Markdown is not markup, so HTML escaping would corrupt the output.
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+    )
+    env.filters["ts"] = _format_timestamp
+    env.filters["pct"] = _format_percent
+    env.filters["duration"] = _format_duration
+    env.filters["oneline"] = _oneline
+    return env
+
+
+class PdfRenderer:
+    """PDF export, converted from the Markdown report via HTML."""
+
+    media_type = "application/pdf"
+    extension = "pdf"
+
+    def __init__(self, markdown_renderer: MarkdownRenderer | None = None) -> None:
+        self._markdown = markdown_renderer or MarkdownRenderer()
+
+    def render(self, summary: IncidentSummary) -> bytes:
+        html = self._to_html(self._markdown.render_text(summary))
+        return self._to_pdf(_to_latin1(html))
+
+    @staticmethod
+    def _to_html(markdown_text: str) -> str:
+        try:
+            import markdown
+        except ImportError as exc:  # pragma: no cover - dependency guard
+            raise ReportRenderError(
+                "The `markdown` package is required for PDF reports. Install it "
+                "with `pip install markdown`."
+            ) from exc
+        return markdown.markdown(markdown_text, extensions=["tables"])
+
+    @staticmethod
+    def _to_pdf(html: str) -> bytes:
+        try:
+            from fpdf import FPDF
+        except ImportError as exc:
+            raise ReportRenderError(
+                "PDF export requires fpdf2. Install it with `pip install fpdf2`, "
+                "or request the report as markdown or json."
+            ) from exc
+
+        pdf = FPDF()
+        pdf.set_auto_page_break(auto=True, margin=15)
+        pdf.add_page()
+        pdf.set_font("Helvetica", size=9)
+        try:
+            pdf.write_html(html)
+        except Exception as exc:
+            raise ReportRenderError(f"PDF generation failed: {exc}") from exc
+        return bytes(pdf.output())
+
+
+def _to_latin1(text: str) -> str:
+    for source, replacement in _LATIN1_SUBSTITUTIONS.items():
+        text = text.replace(source, replacement)
+    # Anything still outside latin-1 becomes "?" rather than failing the export.
+    return text.encode("latin-1", "replace").decode("latin-1")
+
+
+_RENDERERS: dict[str, ReportRenderer] = {
+    "markdown": MarkdownRenderer(),
+    "json": JsonRenderer(),
+    "pdf": PdfRenderer(),
+}
+
+SUPPORTED_FORMATS = get_args(ReportFormat)
+
+assert set(_RENDERERS) == set(SUPPORTED_FORMATS), (
+    "every ReportFormat needs a renderer"
+)
+
+
+def get_renderer(report_format: str) -> ReportRenderer:
+    try:
+        return _RENDERERS[report_format]
+    except KeyError as exc:
+        raise ReportRenderError(
+            f"Unsupported report format {report_format!r}. "
+            f"Supported: {', '.join(SUPPORTED_FORMATS)}."
+        ) from exc

--- a/services/reporting/templates/summary.md.j2
+++ b/services/reporting/templates/summary.md.j2
@@ -1,0 +1,98 @@
+{#
+  Markdown incident summary.  The PDF renderer converts this same output to
+  HTML, so report content is defined here once and cannot drift between formats.
+#}
+# Incident Summary Report
+
+| | |
+| --- | --- |
+| **Window** | {{ s.window.start_ms | ts }} → {{ s.window.end_ms | ts }} ({{ s.window.duration_seconds | duration }}) |
+| **Cameras** | {{ s.cameras | join(", ") if s.cameras else "none" }} |
+| **Generated** | {{ s.generated_at_ms | ts }} |
+{% if s.truncated %}
+> **Note:** the alert cap for a single report was reached. This summary covers the
+> earliest alerts in the window only — narrow the range for complete coverage.
+{% endif %}
+
+## Overview
+
+| Metric | Value |
+| --- | --- |
+| Total alerts | {{ s.total_alerts }} |
+| Suspicious | {{ s.suspicious_alerts }} |
+| Normal | {{ s.normal_alerts }} |
+| Actionable | {{ s.actionable_alerts }} |
+
+{% if s.total_alerts == 0 %}
+No alerts were recorded in this window.
+{% else %}
+## Confidence
+
+| Metric | Value |
+| --- | --- |
+| Mean | {{ s.confidence.mean | pct }} |
+| Median | {{ s.confidence.median | pct }} |
+| Range | {{ s.confidence.minimum | pct }} – {{ s.confidence.maximum | pct }} |
+| Std. deviation | {{ (s.confidence.stdev | pct) if s.confidence.stdev is not none else "n/a (single sample)" }} |
+| High / Medium / Low tier | {{ s.confidence.high_tier_count }} / {{ s.confidence.medium_tier_count }} / {{ s.confidence.low_tier_count }} |
+
+## Object Summary
+
+{% if s.by_object_type %}
+| Object | Alerts | Suspicious | Mean conf. | Max conf. | Mean severity |
+| --- | --- | --- | --- | --- | --- |
+{% for g in s.by_object_type %}
+| {{ g.key }} | {{ g.count }} | {{ g.suspicious_count }} | {{ g.mean_confidence | pct }} | {{ g.max_confidence | pct }} | {{ g.mean_severity | pct }} |
+{% endfor %}
+
+An alert reporting several object classes is counted under each of them, so
+these counts may total more than {{ s.total_alerts }}.
+{% else %}
+No object classes recorded.
+{% endif %}
+
+## Zone Summary
+
+{% if s.by_zone %}
+| Zone | Alerts | Suspicious | Mean conf. | Max conf. | Mean severity |
+| --- | --- | --- | --- | --- | --- |
+{% for g in s.by_zone %}
+| {{ g.key }} | {{ g.count }} | {{ g.suspicious_count }} | {{ g.mean_confidence | pct }} | {{ g.max_confidence | pct }} | {{ g.mean_severity | pct }} |
+{% endfor %}
+{% else %}
+No zones recorded.
+{% endif %}
+
+## Suspicious Activities
+
+{% if s.top_suspicious %}
+Ranked by severity, highest first.
+
+{% for e in s.top_suspicious %}
+### {{ loop.index }}. {{ e.zone or "unknown zone" }} — severity {{ e.severity_score | pct }}
+
+- **Time:** {{ e.timestamp_ms | ts }}
+- **Camera / track:** {{ e.camera_id }} / {{ e.track_id }}
+- **Confidence:** {{ e.confidence | pct }}
+- **Key signal:** {{ e.key_signal or "n/a" }}
+{% if e.object_labels %}
+- **Objects:** {{ e.object_labels | join(", ") }}
+{% endif %}
+{% if e.feedback %}
+- **Operator verdict:** {{ e.feedback }}
+{% endif %}
+- **Assessment:** {{ e.reason }}
+
+{% endfor %}
+{% else %}
+No suspicious activity was detected in this window.
+{% endif %}
+
+## Event Timeline
+
+| Time | Camera | Track | Verdict | Zone | Conf. | Severity | Assessment |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+{% for e in s.timeline %}
+| {{ e.timestamp_ms | ts }} | {{ e.camera_id }} | {{ e.track_id }} | {{ e.label }} | {{ e.zone or "—" }} | {{ e.confidence | pct }} | {{ e.severity_score | pct }} | {{ e.reason | oneline }} |
+{% endfor %}
+{% endif %}

--- a/services/reporting/templates/summary.md.j2
+++ b/services/reporting/templates/summary.md.j2
@@ -7,7 +7,7 @@
 | | |
 | --- | --- |
 | **Window** | {{ s.window.start_ms | ts }} → {{ s.window.end_ms | ts }} ({{ s.window.duration_seconds | duration }}) |
-| **Cameras** | {{ s.cameras | join(", ") if s.cameras else "none" }} |
+| **Cameras** | {{ (s.cameras | join(", ") | oneline) if s.cameras else "none" }} |
 | **Generated** | {{ s.generated_at_ms | ts }} |
 {% if s.truncated %}
 > **Note:** the alert cap for a single report was reached. This summary covers the
@@ -42,7 +42,7 @@ No alerts were recorded in this window.
 | Object | Alerts | Suspicious | Mean conf. | Max conf. | Mean severity |
 | --- | --- | --- | --- | --- | --- |
 {% for g in s.by_object_type %}
-| {{ g.key }} | {{ g.count }} | {{ g.suspicious_count }} | {{ g.mean_confidence | pct }} | {{ g.max_confidence | pct }} | {{ g.mean_severity | pct }} |
+| {{ g.key | oneline }} | {{ g.count }} | {{ g.suspicious_count }} | {{ g.mean_confidence | pct }} | {{ g.max_confidence | pct }} | {{ g.mean_severity | pct }} |
 {% endfor %}
 
 An alert reporting several object classes is counted under each of them, so
@@ -57,7 +57,7 @@ No object classes recorded.
 | Zone | Alerts | Suspicious | Mean conf. | Max conf. | Mean severity |
 | --- | --- | --- | --- | --- | --- |
 {% for g in s.by_zone %}
-| {{ g.key }} | {{ g.count }} | {{ g.suspicious_count }} | {{ g.mean_confidence | pct }} | {{ g.max_confidence | pct }} | {{ g.mean_severity | pct }} |
+| {{ g.key | oneline }} | {{ g.count }} | {{ g.suspicious_count }} | {{ g.mean_confidence | pct }} | {{ g.max_confidence | pct }} | {{ g.mean_severity | pct }} |
 {% endfor %}
 {% else %}
 No zones recorded.
@@ -69,19 +69,19 @@ No zones recorded.
 Ranked by severity, highest first.
 
 {% for e in s.top_suspicious %}
-### {{ loop.index }}. {{ e.zone or "unknown zone" }} — severity {{ e.severity_score | pct }}
+### {{ loop.index }}. {{ (e.zone | oneline) if e.zone else "unknown zone" }} — severity {{ e.severity_score | pct }}
 
 - **Time:** {{ e.timestamp_ms | ts }}
-- **Camera / track:** {{ e.camera_id }} / {{ e.track_id }}
+- **Camera / track:** {{ e.camera_id | oneline }} / {{ e.track_id }}
 - **Confidence:** {{ e.confidence | pct }}
-- **Key signal:** {{ e.key_signal or "n/a" }}
+- **Key signal:** {{ (e.key_signal | oneline) if e.key_signal else "n/a" }}
 {% if e.object_labels %}
-- **Objects:** {{ e.object_labels | join(", ") }}
+- **Objects:** {{ e.object_labels | join(", ") | oneline }}
 {% endif %}
 {% if e.feedback %}
-- **Operator verdict:** {{ e.feedback }}
+- **Operator verdict:** {{ e.feedback | oneline }}
 {% endif %}
-- **Assessment:** {{ e.reason }}
+- **Assessment:** {{ e.reason | oneline }}
 
 {% endfor %}
 {% else %}
@@ -93,6 +93,6 @@ No suspicious activity was detected in this window.
 | Time | Camera | Track | Verdict | Zone | Conf. | Severity | Assessment |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 {% for e in s.timeline %}
-| {{ e.timestamp_ms | ts }} | {{ e.camera_id }} | {{ e.track_id }} | {{ e.label }} | {{ e.zone or "—" }} | {{ e.confidence | pct }} | {{ e.severity_score | pct }} | {{ e.reason | oneline }} |
+| {{ e.timestamp_ms | ts }} | {{ e.camera_id | oneline }} | {{ e.track_id }} | {{ e.label }} | {{ (e.zone | oneline) if e.zone else "—" }} | {{ e.confidence | pct }} | {{ e.severity_score | pct }} | {{ e.reason | oneline }} |
 {% endfor %}
 {% endif %}

--- a/tests/integration/test_reports.py
+++ b/tests/integration/test_reports.py
@@ -1,0 +1,339 @@
+"""
+tests/integration/test_reports.py
+
+Integration tests for GET /reports/summary.
+
+The store dependency is overridden with a fakeredis-backed MemoryStore, so no
+Redis server is required.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import fakeredis
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import apps.backend.main as backend
+from apps.backend.deps import get_store
+from libs.schemas.reasoning import ReasoningResult
+from services.memory.ring_buffer import MemoryStore
+
+WINDOW_START = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def store() -> MemoryStore:
+    return MemoryStore(redis_client=fakeredis.FakeRedis(decode_responses=True))
+
+
+@pytest.fixture()
+def app(store):
+    backend.app.dependency_overrides[get_store] = lambda: store
+    yield backend.app
+    backend.app.dependency_overrides.pop(get_store, None)
+
+
+def seed_alert(
+    store: MemoryStore,
+    *,
+    alert_id: str,
+    offset_seconds: float = 60,
+    camera_id: str = "cam_01",
+    label: str = "Suspicious",
+    confidence: float = 0.88,
+    severity: float = 0.9,
+    zone: str | None = "restricted_door",
+    object_labels: list[str] | None = None,
+    reason: str = "Repeated keypad interaction suggests an entry attempt.",
+) -> None:
+    timestamp_ms = (WINDOW_START + timedelta(seconds=offset_seconds)).timestamp() * 1000
+    alert = ReasoningResult(
+        track_id       = 3,
+        camera_id      = camera_id,
+        label          = label,
+        confidence     = confidence,
+        reason         = reason,
+        key_signal     = "near_keypad",
+        timestamp_ms   = timestamp_ms,
+        severity_score = severity,
+        alert_id       = alert_id,
+        zone           = zone,
+        object_labels  = ["person"] if object_labels is None else object_labels,
+    )
+    store.store_alert(
+        alert_json=alert.model_dump_json(), timestamp_ms=timestamp_ms, camera_id=camera_id
+    )
+
+
+def window_params(hours: float = 1.0) -> dict[str, str]:
+    return {
+        "start": WINDOW_START.isoformat(),
+        "end": (WINDOW_START + timedelta(hours=hours)).isoformat(),
+    }
+
+
+async def get_report(app, **params):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.get("/reports/summary", params={**window_params(), **params})
+
+
+# ── Formats ───────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_markdown_is_the_default_format(app, store):
+    seed_alert(store, alert_id="a1")
+
+    response = await get_report(app)
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/markdown")
+    assert "# Incident Summary Report" in response.text
+
+
+@pytest.mark.asyncio
+async def test_json_format_returns_the_structured_summary(app, store):
+    seed_alert(store, alert_id="a1", zone="keypad_area", object_labels=["person", "backpack"])
+
+    response = await get_report(app, format="json")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert body["total_alerts"] == 1
+    assert body["suspicious_alerts"] == 1
+    assert body["timeline"][0]["alert_id"] == "a1"
+    assert {g["key"] for g in body["by_object_type"]} == {"person", "backpack"}
+    assert [g["key"] for g in body["by_zone"]] == ["keypad_area"]
+
+
+@pytest.mark.asyncio
+async def test_pdf_format_returns_a_pdf_document(app, store):
+    pytest.importorskip("fpdf")
+    seed_alert(store, alert_id="a1")
+
+    response = await get_report(app, format="pdf")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+    assert response.content.startswith(b"%PDF-")
+
+
+@pytest.mark.asyncio
+async def test_unsupported_format_is_rejected_before_reaching_the_store(app):
+    response = await get_report(app, format="docx")
+
+    assert response.status_code == 422
+
+
+# ── Window handling ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_only_alerts_inside_the_window_are_reported(app, store):
+    seed_alert(store, alert_id="inside", offset_seconds=60)
+    seed_alert(store, alert_id="before", offset_seconds=-7_200)
+    seed_alert(store, alert_id="after", offset_seconds=7_200)
+
+    body = (await get_report(app, format="json")).json()
+
+    assert [e["alert_id"] for e in body["timeline"]] == ["inside"]
+
+
+@pytest.mark.asyncio
+async def test_window_defaults_to_the_recent_past_when_omitted(app, store):
+    """With no bounds the endpoint reports the last `report_default_window_hours`."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/reports/summary", params={"format": "json"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["window"]["end_ms"] > body["window"]["start_ms"]
+    assert body["total_alerts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_inverted_window_is_rejected(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/reports/summary",
+            params={
+                "start": (WINDOW_START + timedelta(hours=2)).isoformat(),
+                "end": WINDOW_START.isoformat(),
+            },
+        )
+
+    assert response.status_code == 422
+    assert "earlier" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_excessive_window_is_rejected(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/reports/summary",
+            params={
+                "start": WINDOW_START.isoformat(),
+                "end": (WINDOW_START + timedelta(days=400)).isoformat(),
+            },
+        )
+
+    assert response.status_code == 422
+    assert "narrower" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_naive_timestamps_are_interpreted_as_utc(app, store):
+    seed_alert(store, alert_id="a1", offset_seconds=60)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/reports/summary",
+            params={
+                "start": "2026-06-10T12:00:00",
+                "end": "2026-06-10T13:00:00",
+                "format": "json",
+            },
+        )
+
+    assert response.json()["total_alerts"] == 1
+
+
+# ── Filtering ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_camera_filter_restricts_the_report(app, store):
+    seed_alert(store, alert_id="a1", camera_id="cam_01")
+    seed_alert(store, alert_id="a2", camera_id="cam_02")
+
+    body = (await get_report(app, format="json", camera_id="cam_02")).json()
+
+    assert body["cameras"] == ["cam_02"]
+    assert [e["alert_id"] for e in body["timeline"]] == ["a2"]
+
+
+@pytest.mark.asyncio
+async def test_all_cameras_covered_by_default(app, store):
+    seed_alert(store, alert_id="a1", camera_id="cam_01")
+    seed_alert(store, alert_id="a2", camera_id="cam_02")
+
+    body = (await get_report(app, format="json")).json()
+
+    assert body["cameras"] == ["cam_01", "cam_02"]
+    assert body["total_alerts"] == 2
+
+
+@pytest.mark.asyncio
+async def test_dismissed_alerts_can_be_excluded(app, store):
+    seed_alert(store, alert_id="kept", offset_seconds=60)
+    seed_alert(store, alert_id="dismissed", offset_seconds=120)
+    store.store_feedback("dismissed", "dismissed", "op_1", "", 0.0)
+
+    body = (await get_report(app, format="json", include_dismissed=False)).json()
+
+    assert [e["alert_id"] for e in body["timeline"]] == ["kept"]
+
+
+@pytest.mark.asyncio
+async def test_operator_verdicts_appear_in_the_report(app, store):
+    seed_alert(store, alert_id="a1")
+    store.store_feedback("a1", "confirmed", "op_1", "", 0.0)
+
+    body = (await get_report(app, format="json")).json()
+
+    assert body["timeline"][0]["feedback"] == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_top_n_limits_the_spotlight(app, store):
+    for i in range(4):
+        seed_alert(store, alert_id=f"a{i}", offset_seconds=60 + i, severity=i / 10)
+
+    body = (await get_report(app, format="json", top_n=2)).json()
+
+    assert len(body["top_suspicious"]) == 2
+    assert len(body["timeline"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_top_n_is_bounded(app):
+    response = await get_report(app, top_n=0)
+
+    assert response.status_code == 422
+
+
+# ── Robustness ────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_empty_window_reports_zero_alerts(app):
+    response = await get_report(app)
+
+    assert response.status_code == 200
+    assert "No alerts were recorded in this window." in response.text
+
+
+@pytest.mark.asyncio
+async def test_corrupt_alert_does_not_sink_the_report(app, store):
+    """One unreadable record must not deny the operator the rest of the window."""
+    seed_alert(store, alert_id="good", offset_seconds=60)
+    timestamp_ms = (WINDOW_START + timedelta(seconds=90)).timestamp() * 1000
+    store.store_alert(alert_json="{not valid json", timestamp_ms=timestamp_ms)
+
+    body = (await get_report(app, format="json")).json()
+
+    assert [e["alert_id"] for e in body["timeline"]] == ["good"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_alerts_without_provenance_are_grouped_as_unknown(app, store):
+    """Alerts predating provenance capture still appear, bucketed explicitly."""
+    timestamp_ms = (WINDOW_START + timedelta(seconds=60)).timestamp() * 1000
+    legacy = {
+        "track_id": 9,
+        "camera_id": "cam_01",
+        "label": "Suspicious",
+        "confidence": 0.7,
+        "reason": "Loitering by the door.",
+        "key_signal": "lingering",
+        "timestamp_ms": timestamp_ms,
+        "vlm_captions": [],
+        "severity_score": 0.5,
+        "alert_id": "legacy-1",
+    }
+    store.store_alert(alert_json=json.dumps(legacy), timestamp_ms=timestamp_ms)
+
+    body = (await get_report(app, format="json")).json()
+
+    assert body["total_alerts"] == 1
+    assert [g["key"] for g in body["by_zone"]] == ["unknown"]
+    assert [g["key"] for g in body["by_object_type"]] == ["unknown"]
+
+
+@pytest.mark.asyncio
+async def test_download_flag_sets_an_attachment_filename(app, store):
+    seed_alert(store, alert_id="a1")
+
+    response = await get_report(app, download=True)
+
+    disposition = response.headers["content-disposition"]
+    assert disposition.startswith("attachment;")
+    assert disposition.endswith('.md"')
+
+
+@pytest.mark.asyncio
+async def test_reports_are_served_inline_by_default(app, store):
+    seed_alert(store, alert_id="a1")
+
+    response = await get_report(app)
+
+    assert response.headers["content-disposition"].startswith("inline;")

--- a/tests/test_alert_store.py
+++ b/tests/test_alert_store.py
@@ -165,6 +165,35 @@ def test_non_positive_limit_returns_nothing(store):
     assert store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000, limit=0) == []
 
 
+def test_limit_is_global_not_per_camera(store):
+    """Three cameras each holding `limit` alerts must still yield `limit` total."""
+    for camera in ("cam_01", "cam_02", "cam_03"):
+        for i in range(4):
+            seed_alert(
+                store,
+                alert_id=f"{camera}_a{i}",
+                offset_ms=i * 1_000,
+                camera_id=camera,
+            )
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 100_000, limit=4)
+
+    assert len(raws) == 4
+
+
+def test_limit_keeps_the_earliest_alerts_across_cameras(store):
+    """The global cap must not favour whichever camera key is scanned first."""
+    seed_alert(store, alert_id="cam1_t4", offset_ms=4_000, camera_id="cam_01")
+    seed_alert(store, alert_id="cam1_t5", offset_ms=5_000, camera_id="cam_01")
+    seed_alert(store, alert_id="cam2_t1", offset_ms=1_000, camera_id="cam_02")
+    seed_alert(store, alert_id="cam2_t2", offset_ms=2_000, camera_id="cam_02")
+    seed_alert(store, alert_id="cam3_t3", offset_ms=3_000, camera_id="cam_03")
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 100_000, limit=3)
+
+    assert alert_ids(raws) == ["cam2_t1", "cam2_t2", "cam3_t3"]
+
+
 # ── Bulk feedback ─────────────────────────────────────────────────────────────
 
 def test_bulk_feedback_resolves_only_alerts_with_verdicts(store):

--- a/tests/test_alert_store.py
+++ b/tests/test_alert_store.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for alert querying on the Redis-backed store.
+
+Covers the time-window and bulk-feedback reads that incident summary reports
+depend on, plus the guarantee that alerts written before provenance fields
+existed still deserialize.  All Redis access is fakeredis.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import fakeredis
+import pytest
+
+from libs.schemas.reasoning import ReasoningResult
+from services.memory.ring_buffer import MemoryStore
+
+BASE_MS = 1_718_000_000_000.0
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore(redis_client=fakeredis.FakeRedis(decode_responses=True))
+
+
+def seed_alert(
+    store: MemoryStore,
+    *,
+    alert_id: str,
+    offset_ms: float,
+    camera_id: str = "cam_01",
+    zone: str | None = "restricted_door",
+) -> ReasoningResult:
+    alert = ReasoningResult(
+        track_id       = 1,
+        camera_id      = camera_id,
+        label          = "Suspicious",
+        confidence     = 0.8,
+        reason         = "Lingering near the keypad.",
+        timestamp_ms   = BASE_MS + offset_ms,
+        severity_score = 0.6,
+        alert_id       = alert_id,
+        zone           = zone,
+        object_labels  = ["person"],
+    )
+    store.store_alert(
+        alert_json   = alert.model_dump_json(),
+        timestamp_ms = alert.timestamp_ms,
+        camera_id    = camera_id,
+    )
+    return alert
+
+
+def alert_ids(raws: list[str]) -> list[str]:
+    return [json.loads(raw)["alert_id"] for raw in raws]
+
+
+# ── Time-window queries ───────────────────────────────────────────────────────
+
+def test_range_query_returns_alerts_oldest_first(store):
+    seed_alert(store, alert_id="third", offset_ms=3_000)
+    seed_alert(store, alert_id="first", offset_ms=1_000)
+    seed_alert(store, alert_id="second", offset_ms=2_000)
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000, camera_id="cam_01")
+
+    assert alert_ids(raws) == ["first", "second", "third"]
+
+
+def test_range_bounds_are_inclusive(store):
+    seed_alert(store, alert_id="at_start", offset_ms=0)
+    seed_alert(store, alert_id="at_end", offset_ms=5_000)
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 5_000, camera_id="cam_01")
+
+    assert set(alert_ids(raws)) == {"at_start", "at_end"}
+
+
+def test_alerts_outside_the_window_are_excluded(store):
+    seed_alert(store, alert_id="before", offset_ms=-60_000)
+    seed_alert(store, alert_id="inside", offset_ms=1_000)
+    seed_alert(store, alert_id="after", offset_ms=60_000)
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000, camera_id="cam_01")
+
+    assert alert_ids(raws) == ["inside"]
+
+
+def test_empty_window_returns_nothing(store):
+    seed_alert(store, alert_id="a1", offset_ms=1_000)
+
+    assert store.get_alerts_in_range(BASE_MS + 500_000, BASE_MS + 600_000) == []
+
+
+def test_inverted_window_returns_nothing_rather_than_raising(store):
+    seed_alert(store, alert_id="a1", offset_ms=1_000)
+
+    assert store.get_alerts_in_range(BASE_MS + 10_000, BASE_MS) == []
+
+
+def test_unknown_camera_returns_nothing(store):
+    seed_alert(store, alert_id="a1", offset_ms=1_000, camera_id="cam_01")
+
+    assert store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000, camera_id="cam_99") == []
+
+
+# ── Multi-camera aggregation ──────────────────────────────────────────────────
+
+def test_omitting_camera_id_aggregates_every_camera(store):
+    seed_alert(store, alert_id="a1", offset_ms=1_000, camera_id="cam_01")
+    seed_alert(store, alert_id="a2", offset_ms=2_000, camera_id="cam_02")
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000)
+
+    assert set(alert_ids(raws)) == {"a1", "a2"}
+
+
+def test_cross_camera_results_stay_chronological(store):
+    """Each camera's slice arrives sorted; the merge must re-sort globally."""
+    seed_alert(store, alert_id="cam1_late", offset_ms=4_000, camera_id="cam_01")
+    seed_alert(store, alert_id="cam2_early", offset_ms=1_000, camera_id="cam_02")
+    seed_alert(store, alert_id="cam1_mid", offset_ms=2_000, camera_id="cam_01")
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000)
+
+    assert alert_ids(raws) == ["cam2_early", "cam1_mid", "cam1_late"]
+
+
+def test_camera_filter_restricts_results(store):
+    seed_alert(store, alert_id="a1", offset_ms=1_000, camera_id="cam_01")
+    seed_alert(store, alert_id="a2", offset_ms=2_000, camera_id="cam_02")
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000, camera_id="cam_02")
+
+    assert alert_ids(raws) == ["a2"]
+
+
+# ── Limit ─────────────────────────────────────────────────────────────────────
+
+def test_limit_caps_returned_alerts(store):
+    for i in range(10):
+        seed_alert(store, alert_id=f"a{i}", offset_ms=i * 1_000)
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 100_000, limit=4)
+
+    assert len(raws) == 4
+
+
+def test_limit_keeps_the_earliest_alerts_in_the_window(store):
+    for i in range(5):
+        seed_alert(store, alert_id=f"a{i}", offset_ms=i * 1_000)
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 100_000, limit=2)
+
+    assert alert_ids(raws) == ["a0", "a1"]
+
+
+def test_non_positive_limit_returns_nothing(store):
+    seed_alert(store, alert_id="a1", offset_ms=1_000)
+
+    assert store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000, limit=0) == []
+
+
+# ── Bulk feedback ─────────────────────────────────────────────────────────────
+
+def test_bulk_feedback_resolves_only_alerts_with_verdicts(store):
+    store.store_feedback("a1", "confirmed", "op_1", "", BASE_MS)
+    store.store_feedback("a2", "dismissed", "op_1", "", BASE_MS)
+
+    resolved = store.get_feedback_bulk(["a1", "a2", "a3"])
+
+    assert resolved == {"a1": "confirmed", "a2": "dismissed"}
+
+
+def test_bulk_feedback_handles_empty_input(store):
+    assert store.get_feedback_bulk([]) == {}
+
+
+def test_bulk_feedback_matches_single_lookup(store):
+    store.store_feedback("a1", "confirmed", "op_1", "", BASE_MS)
+
+    assert store.get_feedback_bulk(["a1"])["a1"] == store.get_feedback("a1")
+
+
+# ── Backward compatibility ────────────────────────────────────────────────────
+
+def test_alerts_stored_before_provenance_fields_still_parse():
+    """Alerts already in Redis lack zone/object_labels and must remain readable."""
+    legacy = {
+        "track_id": 4,
+        "camera_id": "cam_01",
+        "label": "Suspicious",
+        "confidence": 0.77,
+        "reason": "Loitering by the door.",
+        "key_signal": "lingering",
+        "timestamp_ms": BASE_MS,
+        "vlm_captions": [],
+        "severity_score": 0.5,
+        "alert_id": "legacy-1",
+    }
+
+    alert = ReasoningResult(**legacy)
+
+    assert alert.zone is None
+    assert alert.zones_visited == []
+    assert alert.object_labels == []
+
+
+def test_provenance_fields_round_trip_through_storage(store):
+    seeded = seed_alert(store, alert_id="a1", offset_ms=1_000, zone="keypad_area")
+
+    raws = store.get_alerts_in_range(BASE_MS, BASE_MS + 10_000)
+    restored = ReasoningResult(**json.loads(raws[0]))
+
+    assert restored.zone == "keypad_area"
+    assert restored.object_labels == ["person"]
+    assert restored.alert_id == seeded.alert_id

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -6,6 +6,7 @@ Uses MockVLMCaptioner + MockLLMReasoner + fakeredis.
 from __future__ import annotations
 import sys
 import os
+import json
 import time
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -351,3 +352,48 @@ def test_grounding_check_passes_clean_caption(pipeline):
     detections = ["person"]
     gr = pipeline._ground(caption, detections)
     assert gr.grounded is True
+
+
+# ── Alert provenance tests ────────────────────────────────────────────────────
+
+def test_pipeline_records_zone_and_object_labels(pipeline, store):
+    """Summary reports group by these, so they must survive on the alert."""
+    seq = make_suspicious_seq(track_id=20)
+    for e in seq.events:
+        store.store_event(e)
+    frame  = np.zeros((480, 640, 3), dtype=np.uint8)
+    result = pipeline.run(track_id=20, frame=frame, detections=["person", "backpack"])
+    assert result is not None
+    assert result.zone == "safe_corridor"          # first zone visited, as used for dedup
+    assert result.zones_visited == ["safe_corridor", "restricted_door"]
+    assert result.object_labels == ["person", "backpack"]
+
+def test_pipeline_deduplicates_repeated_object_labels(pipeline, store):
+    seq = make_suspicious_seq(track_id=21)
+    for e in seq.events:
+        store.store_event(e)
+    frame  = np.zeros((480, 640, 3), dtype=np.uint8)
+    result = pipeline.run(track_id=21, frame=frame, detections=["person", "person"])
+    assert result is not None
+    assert result.object_labels == ["person"]
+
+def test_pipeline_leaves_zone_none_when_no_zone_visited(pipeline, store):
+    """'unknown' is normalised to None so it matches pre-provenance alerts."""
+    seq = make_normal_seq(track_id=22)
+    for e in seq.events:
+        store.store_event(e)
+    frame  = np.zeros((480, 640, 3), dtype=np.uint8)
+    result = pipeline.run(track_id=22, frame=frame)
+    assert result is not None
+    assert result.zone is None
+    assert result.zones_visited == []
+
+def test_pipeline_provenance_persists_to_storage(pipeline, store):
+    seq = make_suspicious_seq(track_id=23)
+    for e in seq.events:
+        store.store_event(e)
+    frame = np.zeros((480, 640, 3), dtype=np.uint8)
+    pipeline.run(track_id=23, frame=frame, detections=["person"])
+    stored = ReasoningResult(**json.loads(store.get_alerts("cam_01", limit=1)[0]))
+    assert stored.zone == "safe_corridor"
+    assert stored.object_labels == ["person"]

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -364,7 +364,7 @@ def test_pipeline_records_zone_and_object_labels(pipeline, store):
     frame  = np.zeros((480, 640, 3), dtype=np.uint8)
     result = pipeline.run(track_id=20, frame=frame, detections=["person", "backpack"])
     assert result is not None
-    assert result.zone == "safe_corridor"          # first zone visited, as used for dedup
+    assert result.zone == "restricted_door"        # where the behaviour happened
     assert result.zones_visited == ["safe_corridor", "restricted_door"]
     assert result.object_labels == ["person", "backpack"]
 
@@ -378,7 +378,7 @@ def test_pipeline_deduplicates_repeated_object_labels(pipeline, store):
     assert result.object_labels == ["person"]
 
 def test_pipeline_leaves_zone_none_when_no_zone_visited(pipeline, store):
-    """'unknown' is normalised to None so it matches pre-provenance alerts."""
+    """No zone visited leaves None, matching pre-provenance alerts."""
     seq = make_normal_seq(track_id=22)
     for e in seq.events:
         store.store_event(e)
@@ -395,5 +395,21 @@ def test_pipeline_provenance_persists_to_storage(pipeline, store):
     frame = np.zeros((480, 640, 3), dtype=np.uint8)
     pipeline.run(track_id=23, frame=frame, detections=["person"])
     stored = ReasoningResult(**json.loads(store.get_alerts("cam_01", limit=1)[0]))
-    assert stored.zone == "safe_corridor"
+    assert stored.zone == "restricted_door"
     assert stored.object_labels == ["person"]
+
+def test_pipeline_reports_the_latest_zone_not_the_deduped_order(pipeline, store):
+    """A track that returns to an earlier zone is reported in that zone.
+
+    `zones_visited` is de-duplicated for readability, so the alert zone comes
+    from the raw event order rather than the last unique entry.
+    """
+    seq = make_suspicious_seq(track_id=24)
+    seq.events[-1].zone = "safe_corridor"
+    for e in seq.events:
+        store.store_event(e)
+    frame  = np.zeros((480, 640, 3), dtype=np.uint8)
+    result = pipeline.run(track_id=24, frame=frame, detections=["person"])
+    assert result is not None
+    assert result.zone == "safe_corridor"
+    assert result.zones_visited == ["safe_corridor", "restricted_door"]

--- a/tests/test_report_aggregator.py
+++ b/tests/test_report_aggregator.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -33,6 +34,7 @@ def make_alert(
     zone: str | None = "restricted_door",
     object_labels: list[str] | None = None,
     reason: str = "Lingering near the keypad for an extended period.",
+    key_signal: str = "lingering",
 ) -> ReasoningResult:
     return ReasoningResult(
         track_id       = track_id,
@@ -40,7 +42,7 @@ def make_alert(
         label          = label,
         confidence     = confidence,
         reason         = reason,
-        key_signal     = "lingering",
+        key_signal     = key_signal,
         timestamp_ms   = BASE_MS + offset_ms,
         severity_score = severity,
         alert_id       = alert_id,
@@ -279,6 +281,90 @@ def test_markdown_escapes_pipes_so_tables_survive(window):
     report = get_renderer("markdown").render(build_summary(alerts, window)).decode()
 
     assert r"Left bag \| then walked away" in report
+
+
+# ── Untrusted text in report cells ────────────────────────────────────────────
+#
+# `reason` and `key_signal` are model-generated and `camera_id` arrives on the
+# ingest request, so any of them can contain Markdown or HTML metacharacters.
+
+TIMELINE_COLUMNS = 8
+
+
+def markdown_report(window, **alert_kwargs) -> str:
+    summary = build_summary([make_alert(**alert_kwargs)], window)
+    return get_renderer("markdown").render(summary).decode()
+
+
+def timeline_row(report: str) -> str:
+    """The single alert row from the Event Timeline table."""
+    rows = [
+        line for line in report.splitlines()
+        if line.startswith("| ") and " UTC |" in line
+    ]
+    assert len(rows) == 1, f"expected one timeline row, got {len(rows)}"
+    return rows[0]
+
+
+def cell_count(row: str) -> int:
+    """Cells in a Markdown row, ignoring escaped pipes."""
+    return len(re.split(r"(?<!\\)\|", row)) - 2
+
+
+def test_reason_containing_a_pipe_keeps_the_row_intact(window):
+    row = timeline_row(markdown_report(window, reason="Left bag | walked off"))
+
+    assert cell_count(row) == TIMELINE_COLUMNS
+
+
+def test_camera_id_containing_a_pipe_keeps_the_row_intact(window):
+    """camera_id comes from the ingest request, so it is client-controlled."""
+    row = timeline_row(markdown_report(window, camera_id="cam | rogue"))
+
+    assert cell_count(row) == TIMELINE_COLUMNS
+    assert r"cam \| rogue" in row
+
+
+def test_zone_containing_a_pipe_keeps_the_row_intact(window):
+    row = timeline_row(markdown_report(window, zone="door | annex"))
+
+    assert cell_count(row) == TIMELINE_COLUMNS
+
+
+def test_newline_in_reason_collapses_to_one_row(window):
+    report = markdown_report(window, reason="Loitered.\nThen left.\n\nReturned.")
+
+    assert "Loitered. Then left. Returned." in timeline_row(report)
+
+
+def test_html_in_reason_is_neutralised(window):
+    report = markdown_report(window, reason="Carried <b>a bag</b>")
+
+    assert "<b>" not in report
+    assert "&lt;b&gt;a bag&lt;/b&gt;" in report
+
+
+def test_html_in_key_signal_is_neutralised(window):
+    report = markdown_report(window, key_signal="<img src=x>")
+
+    assert "<img" not in report
+    assert "&lt;img src=x&gt;" in report
+
+
+def test_html_in_zone_is_neutralised_in_group_tables(window):
+    report = markdown_report(window, zone="<script>alert(1)</script>")
+
+    assert "<script>" not in report
+    assert "&lt;script&gt;" in report
+
+
+def test_pdf_export_survives_html_in_report_text(window):
+    """fpdf2 raises on nested tags in a cell, so escaping keeps PDF export alive."""
+    summary = build_summary([make_alert(reason="Carried <img src=x> away")], window)
+
+    pdf = get_renderer("pdf").render(summary)
+
+    assert pdf.startswith(b"%PDF")
 
 
 def test_markdown_flags_truncation_to_the_operator(window):

--- a/tests/test_report_aggregator.py
+++ b/tests/test_report_aggregator.py
@@ -1,0 +1,321 @@
+"""
+Unit tests for incident summary aggregation and rendering.
+
+The aggregator is pure, so these tests need no Redis and no HTTP client.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from libs.schemas.reasoning import ReasoningResult
+from services.reporting import build_summary, get_renderer
+from services.reporting.models import TimeWindow
+from services.reporting.renderers import ReportRenderError
+
+BASE_MS = 1_718_000_000_000.0
+
+
+def make_alert(
+    *,
+    alert_id: str = "alert-1",
+    track_id: int = 1,
+    camera_id: str = "cam_01",
+    label: str = "Suspicious",
+    confidence: float = 0.8,
+    severity: float = 0.5,
+    offset_ms: float = 0.0,
+    zone: str | None = "restricted_door",
+    object_labels: list[str] | None = None,
+    reason: str = "Lingering near the keypad for an extended period.",
+) -> ReasoningResult:
+    return ReasoningResult(
+        track_id       = track_id,
+        camera_id      = camera_id,
+        label          = label,
+        confidence     = confidence,
+        reason         = reason,
+        key_signal     = "lingering",
+        timestamp_ms   = BASE_MS + offset_ms,
+        severity_score = severity,
+        alert_id       = alert_id,
+        zone           = zone,
+        object_labels  = ["person"] if object_labels is None else object_labels,
+    )
+
+
+@pytest.fixture
+def window() -> TimeWindow:
+    return TimeWindow(start_ms=BASE_MS, end_ms=BASE_MS + 3_600_000)
+
+
+# ── Totals and window ─────────────────────────────────────────────────────────
+
+def test_empty_window_produces_zeroed_summary(window):
+    summary = build_summary([], window)
+
+    assert summary.total_alerts == 0
+    assert summary.suspicious_alerts == 0
+    assert summary.normal_alerts == 0
+    assert summary.cameras == []
+    assert summary.by_object_type == []
+    assert summary.timeline == []
+    assert summary.confidence.stdev is None
+
+
+def test_counts_split_by_verdict(window):
+    alerts = [
+        make_alert(alert_id="a1", label="Suspicious"),
+        make_alert(alert_id="a2", label="Normal"),
+        make_alert(alert_id="a3", label="Normal"),
+    ]
+    summary = build_summary(alerts, window)
+
+    assert summary.total_alerts == 3
+    assert summary.suspicious_alerts == 1
+    assert summary.normal_alerts == 2
+
+
+def test_actionable_count_follows_schema_rule(window):
+    """Actionable means Suspicious with confidence >= 0.65 per ReasoningResult."""
+    alerts = [
+        make_alert(alert_id="a1", label="Suspicious", confidence=0.90),
+        make_alert(alert_id="a2", label="Suspicious", confidence=0.40),
+        make_alert(alert_id="a3", label="Normal", confidence=0.99),
+    ]
+    summary = build_summary(alerts, window)
+
+    assert summary.actionable_alerts == 1
+
+
+def test_timeline_sorted_chronologically_regardless_of_input_order(window):
+    alerts = [
+        make_alert(alert_id="late", offset_ms=5_000),
+        make_alert(alert_id="early", offset_ms=1_000),
+        make_alert(alert_id="middle", offset_ms=3_000),
+    ]
+    summary = build_summary(alerts, window)
+
+    assert [e.alert_id for e in summary.timeline] == ["early", "middle", "late"]
+
+
+def test_cameras_are_deduplicated_and_sorted(window):
+    alerts = [
+        make_alert(alert_id="a1", camera_id="cam_02"),
+        make_alert(alert_id="a2", camera_id="cam_01"),
+        make_alert(alert_id="a3", camera_id="cam_02"),
+    ]
+    summary = build_summary(alerts, window)
+
+    assert summary.cameras == ["cam_01", "cam_02"]
+
+
+# ── Confidence statistics ─────────────────────────────────────────────────────
+
+def test_confidence_stats_across_multiple_alerts(window):
+    alerts = [
+        make_alert(alert_id="a1", confidence=0.90),
+        make_alert(alert_id="a2", confidence=0.60),
+        make_alert(alert_id="a3", confidence=0.30),
+    ]
+    stats = build_summary(alerts, window).confidence
+
+    assert stats.mean == pytest.approx(0.60, abs=1e-4)
+    assert stats.median == pytest.approx(0.60, abs=1e-4)
+    assert stats.minimum == pytest.approx(0.30, abs=1e-4)
+    assert stats.maximum == pytest.approx(0.90, abs=1e-4)
+    assert stats.stdev == pytest.approx(0.30, abs=1e-4)
+
+
+def test_stdev_undefined_for_single_sample(window):
+    """One sample has no standard deviation; it must not raise."""
+    stats = build_summary([make_alert(confidence=0.72)], window).confidence
+
+    assert stats.stdev is None
+    assert stats.mean == pytest.approx(0.72)
+
+
+def test_confidence_tier_counts_match_schema_thresholds(window):
+    alerts = [
+        make_alert(alert_id="a1", confidence=0.80),   # high  (>= 0.75)
+        make_alert(alert_id="a2", confidence=0.75),   # high  (boundary)
+        make_alert(alert_id="a3", confidence=0.50),   # medium (boundary)
+        make_alert(alert_id="a4", confidence=0.10),   # low
+    ]
+    stats = build_summary(alerts, window).confidence
+
+    assert (stats.high_tier_count, stats.medium_tier_count, stats.low_tier_count) == (2, 1, 1)
+
+
+# ── Grouping ──────────────────────────────────────────────────────────────────
+
+def test_object_grouping_counts_each_class(window):
+    alerts = [
+        make_alert(alert_id="a1", object_labels=["person", "backpack"]),
+        make_alert(alert_id="a2", object_labels=["person"]),
+    ]
+    groups = {g.key: g for g in build_summary(alerts, window).by_object_type}
+
+    assert groups["person"].count == 2
+    assert groups["backpack"].count == 1
+
+
+def test_alerts_without_object_labels_bucket_as_unknown(window):
+    """Alerts written before provenance capture must still be represented."""
+    summary = build_summary([make_alert(object_labels=[])], window)
+
+    assert [g.key for g in summary.by_object_type] == ["unknown"]
+    assert summary.by_object_type[0].count == 1
+
+
+def test_alerts_without_zone_bucket_as_unknown(window):
+    summary = build_summary([make_alert(zone=None)], window)
+
+    assert [g.key for g in summary.by_zone] == ["unknown"]
+
+
+def test_groups_ordered_by_count_then_key(window):
+    alerts = [
+        make_alert(alert_id="a1", zone="zone_b"),
+        make_alert(alert_id="a2", zone="zone_b"),
+        make_alert(alert_id="a3", zone="zone_a"),
+        make_alert(alert_id="a4", zone="zone_c"),
+    ]
+    keys = [g.key for g in build_summary(alerts, window).by_zone]
+
+    assert keys == ["zone_b", "zone_a", "zone_c"]
+
+
+def test_group_stats_computed_per_bucket(window):
+    alerts = [
+        make_alert(alert_id="a1", zone="dock", label="Suspicious",
+                   confidence=0.90, severity=0.80),
+        make_alert(alert_id="a2", zone="dock", label="Normal",
+                   confidence=0.50, severity=0.20),
+    ]
+    dock = next(g for g in build_summary(alerts, window).by_zone if g.key == "dock")
+
+    assert dock.count == 2
+    assert dock.suspicious_count == 1
+    assert dock.mean_confidence == pytest.approx(0.70)
+    assert dock.max_confidence == pytest.approx(0.90)
+    assert dock.mean_severity == pytest.approx(0.50)
+
+
+# ── Suspicious ranking ────────────────────────────────────────────────────────
+
+def test_top_suspicious_ranked_by_severity_and_excludes_normal(window):
+    alerts = [
+        make_alert(alert_id="mild", label="Suspicious", severity=0.30),
+        make_alert(alert_id="worst", label="Suspicious", severity=0.95),
+        make_alert(alert_id="mid", label="Suspicious", severity=0.60),
+        make_alert(alert_id="benign", label="Normal", severity=0.99),
+    ]
+    top = build_summary(alerts, window).top_suspicious
+
+    assert [e.alert_id for e in top] == ["worst", "mid", "mild"]
+
+
+def test_top_n_limits_spotlight_without_truncating_timeline(window):
+    alerts = [
+        make_alert(alert_id=f"a{i}", severity=i / 10, offset_ms=i * 1000)
+        for i in range(5)
+    ]
+    summary = build_summary(alerts, window, top_n=2)
+
+    assert len(summary.top_suspicious) == 2
+    assert len(summary.timeline) == 5
+
+
+# ── Feedback ──────────────────────────────────────────────────────────────────
+
+def test_operator_feedback_attached_to_timeline(window):
+    alerts = [make_alert(alert_id="a1"), make_alert(alert_id="a2")]
+    summary = build_summary(alerts, window, feedback={"a1": "confirmed"})
+
+    verdicts = {e.alert_id: e.feedback for e in summary.timeline}
+    assert verdicts == {"a1": "confirmed", "a2": None}
+
+
+def test_truncated_flag_is_passed_through(window):
+    assert build_summary([], window, truncated=True).truncated is True
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────────
+
+def test_markdown_report_contains_every_required_section(window):
+    alerts = [make_alert(alert_id="a1", object_labels=["person", "backpack"])]
+    summary = build_summary(alerts, window, generated_at_ms=BASE_MS)
+
+    report = get_renderer("markdown").render(summary).decode()
+
+    for heading in (
+        "# Incident Summary Report",
+        "## Overview",
+        "## Confidence",
+        "## Object Summary",
+        "## Zone Summary",
+        "## Suspicious Activities",
+        "## Event Timeline",
+    ):
+        assert heading in report
+    assert "restricted_door" in report
+    assert "backpack" in report
+
+
+def test_markdown_report_states_when_window_is_empty(window):
+    report = get_renderer("markdown").render(build_summary([], window)).decode()
+
+    assert "No alerts were recorded in this window." in report
+
+
+def test_markdown_escapes_pipes_so_tables_survive(window):
+    alerts = [make_alert(reason="Left bag | then walked away")]
+    report = get_renderer("markdown").render(build_summary(alerts, window)).decode()
+
+    assert r"Left bag \| then walked away" in report
+
+
+def test_markdown_flags_truncation_to_the_operator(window):
+    summary = build_summary([make_alert()], window, truncated=True)
+    report = get_renderer("markdown").render(summary).decode()
+
+    assert "alert cap" in report
+
+
+def test_json_report_is_the_full_summary(window):
+    summary = build_summary([make_alert(alert_id="a1")], window)
+
+    payload = json.loads(get_renderer("json").render(summary))
+
+    assert payload["total_alerts"] == 1
+    assert payload["timeline"][0]["alert_id"] == "a1"
+    assert payload["window"]["start_ms"] == BASE_MS
+
+
+def test_pdf_report_is_a_valid_pdf_document(window):
+    pytest.importorskip("fpdf")
+    summary = build_summary([make_alert()], window)
+
+    body = get_renderer("pdf").render(summary)
+
+    assert body.startswith(b"%PDF-")
+
+
+def test_pdf_survives_characters_outside_latin1(window):
+    """LLM and VLM text carries typographic characters the core fonts lack."""
+    pytest.importorskip("fpdf")
+    alerts = [make_alert(reason="Approach → keypad ×3, ‘testing’ the panel…")]
+    summary = build_summary(alerts, window)
+
+    assert get_renderer("pdf").render(summary).startswith(b"%PDF-")
+
+
+def test_unknown_format_is_rejected():
+    with pytest.raises(ReportRenderError):
+        get_renderer("docx")


### PR DESCRIPTION
## Summary

Adds `GET /reports/summary`, which turns the alerts the reasoning layer has already
produced into an operator-facing incident report for a chosen time window, available
as Markdown (default), JSON, or PDF.

Reports reuse the `reason` text stored with each alert rather than calling a model per
report, so generation is fast, costs nothing, and cannot fail on a provider outage.

Closes #182

## Deliverables from the issue

- [x] **Event timeline** — chronological table of every alert in the window
- [x] **Object summary** — grouped by detected class, with counts and confidence
- [x] **Suspicious activities** — ranked by `severity_score`, depth configurable via `top_n`
- [x] **Confidence scores** — mean, median, range, standard deviation, and high/medium/low tier counts
- [x] **Export PDF**
- [x] **Markdown report**

Also includes a **zone summary**, since zone is the most actionable grouping for
surveillance review, and operator verdicts from `/feedback` are surfaced per alert.

## API

| Query param | Default | Meaning |
|---|---|---|
| `start` | `end` − 24h | ISO-8601 start of window (naive values read as UTC) |
| `end` | now | ISO-8601 end of window |
| `camera_id` | all cameras | Restrict to one camera |
| `format` | `markdown` | `markdown`, `json`, or `pdf` |
| `top_n` | `10` | Suspicious activities to spotlight |
| `include_dismissed` | `true` | Include alerts an operator dismissed |
| `download` | `false` | Serve as a file attachment |

```bash
# Markdown report for the last 24 hours
curl "http://localhost:8000/reports/summary"

# PDF export for one camera over a specific window
curl -o incident.pdf "http://localhost:8000/reports/summary?start=2026-06-15T08:00:00Z&end=2026-06-15T18:00:00Z&camera_id=cam_01&format=pdf&download=true"
```

Invalid windows are rejected with `422` (inverted range, or a span beyond
`REPORT_MAX_WINDOW_HOURS`). A format that cannot be produced in the current
environment returns `503` with an actionable message rather than a stack trace.

## Design notes

**Layering.** `services/reporting/` is split so each piece has one reason to change:
`models.py` (the data contract), `aggregator.py` (pure statistics — no Redis, no HTTP,
no clock), `renderers.py` (formats behind one Protocol and a registry), and
`templates/summary.md.j2`. Because the aggregator is pure, the statistics are unit
testable without fixtures and a report is reproducible for a given window. Adding a
format later means one class plus one registry entry, touching nothing existing.

**One template.** The PDF renderer converts the Markdown renderer's own output to HTML
rather than owning a second template, so the two formats cannot drift.

**Alerts did not store the zone or object type.** Grouping needs both, and neither was
persisted — `ReasoningResult.label` is the `Suspicious`/`Normal` verdict, not an object
class. Reading them back from the ring buffer at report time would be unreliable: it
trims to 50 events per track, expires after `TRACK_TTL_SECONDS`, track IDs are reused,
and the object class was never stored there at all. So `ReasoningResult` now records
`zone`, `zones_visited`, and `object_labels` at alert time, from the zone the pipeline
already computes for the dedup gate and the `detections` argument it already receives.
The same fields are exposed on `GET /alerts`.

**Backward compatible.** All three fields default to empty, so alerts already in Redis
still deserialize and are grouped under `unknown` rather than dropped. There are tests
pinning both behaviours.

**fpdf2 rather than WeasyPrint** (a change from my comment on the issue). WeasyPrint
needs Pango and Cairo present at import time, which no CI workflow here installs, so
`format=pdf` would have failed on a fresh clone. fpdf2 is a pure-Python wheel that works
everywhere. Its core fonts are latin-1 only, so the renderer transliterates typographic
characters — a `×` in a `key_signal` becomes `x` instead of raising — which matters
because VLM and LLM text is arbitrary.

**Performance.** The window query is a single `ZRANGEBYSCORE` (alerts were already
scored by timestamp), key discovery uses `SCAN` rather than `KEYS`, feedback for the
whole window resolves in one pipelined round-trip, `REPORT_MAX_ALERTS` caps how much a
single report can load, and the report flags itself as truncated when that cap is hit.

## New dependencies

`jinja2>=3.1.6`, `markdown>=3.7`, `fpdf2>=2.8.0` — all pure Python, no system libraries.
Jinja2 is floored at 3.1.6 because earlier releases carry HIGH-severity CVEs that the
Trivy step in `phase3-tests.yml` would flag.

## Testing

66 new tests, all passing:

- `tests/test_report_aggregator.py` — aggregation and rendering, no Redis needed. Covers empty windows, verdict splits, tier boundaries, multi-class grouping, ranking, pipe escaping in table cells, and the single-sample case where standard deviation is undefined.
- `tests/test_alert_store.py` — inclusive range bounds, exclusion outside the window, cross-camera merge ordering, the limit cap, bulk feedback, and legacy alert parsing.
- `tests/integration/test_reports.py` — all three formats over HTTP with a fakeredis-backed store, window validation, camera and dismissed filters, `Content-Disposition`, a corrupt-record case, and legacy alerts.
- `tests/test_reasoning.py` — four tests that provenance is attached and persisted.

`332 passed` locally, excluding seven modules that need the heavy ML dependencies
(`ultralytics`, `deep_sort_realtime`, `matplotlib`, Kafka) and `tests/integration/test_backend.py`.
Verified manually against a live `uvicorn` server for all three formats, the filters,
the 422s, and OpenAPI registration.

## Notes for reviewers

- Every change to an existing file is additive: **200 insertions, 0 deletions.**
- `tests/integration/test_backend.py` already fails on `main` (11 errors — it patches a `backend._redis` attribute and calls a `/tracks` route that no longer exist). Unrelated to this PR, and no workflow runs that file.
- No dashboard UI here. The feature-tab glob in `apps/dashboard/src/pages/Dashboard.jsx` is `"./features/*.jsx"` while the features live in `src/features/`, so no tab is ever discovered — the existing Investigation Workspace tab is dead too. That is a pre-existing bug and deserves its own issue rather than being bundled into a backend feature.
- Docs updated: README API reference, `docs/ARCHITECTURE.md` component table and data flow, and `.env.example` for the three new settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incident summary reports with configurable time ranges, camera filtering, dismissal options, and top-alert limits.
  * Reports can be viewed or downloaded as Markdown, JSON, or PDF.
  * Reports include timelines, confidence metrics, alert categories, zones, objects, feedback, and suspicious activity.
  * Alerts now retain zone and detected-object context.
* **Documentation**
  * Added API usage details, report examples, and architecture documentation.
* **Bug Fixes**
  * Improved compatibility with legacy alerts and handling of corrupt records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->