### PR TITLE
feat: add configurable smart alert rules (#183)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,13 @@ API_PORT=8000
 
 # ── Policy ───────────────────────────────────────────────────────────────
 POLICY_PATH=policies/default.yaml
+
+# ── Configurable alert rules ─────────────────────────────────────────────
+# Rules narrow which suspicious activity raises an alert. While this file is
+# absent, Eagle alerts on all suspicious activity:
+#   cp config/alert_rules.example.yaml config/alert_rules.yaml
+ALERT_RULES_PATH=config/alert_rules.yaml
+# Timezone that rule time_windows are evaluated in, e.g. Asia/Kolkata.
+RULES_TIMEZONE=UTC
+# Minimum seconds between checks for edits to the rules file.
+RULES_RELOAD_SECONDS=30.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 __pycache__/
 *.pyc
 eagle_surveillance.egg-info/
+.venv/
+venv/
+
+# Site-specific alert rules, copied from config/alert_rules.example.yaml.
+# Committing these would change which alerts fire for everyone.
+config/alert_rules.yaml

--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ Eagle/
 │   │   ├── vlm.py              # Frame captioning (LLaVA-Next)
 │   │   ├── llm.py              # Temporal reasoning
 │   │   └── prompts.py          # Prompt templates
-│   └── memory/
-│       └── memory.py           # Redis ring buffer
+│   ├── memory/
+│   │   └── memory.py           # Redis ring buffer
+│   └── rules/
+│       └── engine.py           # Configurable alert rule matching
 │
 ├── libs/
 │   ├── schemas/                # Pydantic models
@@ -308,6 +310,85 @@ Human-in-the-loop endpoint to mark an alert as correct or incorrect.
 ```json
 Request: { "alert_id": "alert_001", "correct": false, "note": "Normal employee" }
 ```
+
+### `GET /rules`
+Returns the configured alert rules in evaluation order, so an operator can see
+what the pipeline is currently enforcing. `?enabled_only=true` hides switched-off
+rules; `GET /rules/{rule_id}` returns one.
+
+```json
+Response: [
+  {
+    "id": "restricted_door_person",
+    "enabled": true,
+    "object_types": ["person"],
+    "zones": ["restricted_door"],
+    "action_hints": ["lingering", "near_keypad", "repeated_approach"],
+    "min_confidence": 0.6,
+    "time_windows": [],
+    "cooldown_seconds": null,
+    "description": "Person lingering or repeatedly approaching the secure door."
+  }
+]
+```
+
+---
+
+## 🔔 Configurable Alert Rules
+
+By default Eagle alerts on all suspicious activity: a track that entered a zone,
+dwelled past the threshold, and showed a suspicious action. Alert rules let an
+operator narrow that down — for example, only high-confidence people at the
+secure door, and corridor activity only after hours.
+
+Rules are off until you create the file:
+
+```bash
+cp config/alert_rules.example.yaml config/alert_rules.yaml
+```
+
+```yaml
+rules:
+  - id: after_hours_corridor
+    description: Anyone in the corridor outside working hours.
+    zones: [safe_corridor]
+    min_confidence: 0.55
+    time_windows:
+      - start: "19:00"      # may cross midnight
+        end: "07:00"
+  - id: daytime_corridor_person
+    enabled: false          # kept on file, switched off
+    object_types: [person]
+    zones: [safe_corridor]
+```
+
+| Field | Meaning |
+|---|---|
+| `id` | Unique name, reported on the alert it fired |
+| `enabled` | `false` switches a rule off without deleting it |
+| `object_types` | `person`, `vehicle`, `bag`, `device`, or any raw COCO class |
+| `zones` | Zone names from `config/zones.yaml` |
+| `action_hints` | `lingering`, `near_keypad`, `repeated_approach`, … |
+| `min_confidence` | Detector confidence floor, `0.0`–`1.0` |
+| `time_windows` | `start`/`end` (`HH:MM`) plus optional `days` |
+| `cooldown_seconds` | Per-rule override of `REASONING_COOLDOWN_SECONDS` |
+
+Behaviour worth knowing:
+
+- **Rules narrow, never widen.** Activity must still pass the zone, dwell, and
+  suspicious-action gates; a permissive rule cannot force an alert.
+- **Every dimension is ANDed**, and an omitted one means "any". Rules are tried
+  top to bottom and the first match wins, so put specific rules first.
+- **No rules means no change.** An absent file, an empty file, or every rule
+  disabled leaves the default behaviour intact.
+- **Edits apply live.** The file is re-read when it changes; a malformed edit is
+  logged and the last valid rules stay in force.
+- **Only tracked classes can match.** Tracking currently follows people, so
+  `object_types: [person]` is the useful case today; the other groups are ready
+  for when tracking covers more classes.
+
+Set `ALERT_RULES_PATH` to keep the file elsewhere and `RULES_TIMEZONE` to the
+site's timezone so `time_windows` mean local time.
 
 ---
 

--- a/apps/backend/routes/ingest.py
+++ b/apps/backend/routes/ingest.py
@@ -70,6 +70,7 @@ async def ingest_event(
         track_id           = body.track_id,
         frame_id           = 0,
         timestamp_ms       = body.timestamp_ms,
+        label              = body.label,
         zone               = body.zones[0] if body.zones else None,
         action_hint        = ActionHint.UNKNOWN,
         bbox               = body.bbox or [0, 0, 0, 0],

--- a/apps/backend/routes/rules.py
+++ b/apps/backend/routes/rules.py
@@ -1,0 +1,42 @@
+"""
+GET /rules            — list configured alert rules and their enabled state
+GET /rules/{rule_id}  — fetch one rule
+
+Rules are owned by `config/alert_rules.yaml` and hot-reloaded, so these
+endpoints are read-only: they report what the pipeline is currently enforcing.
+Toggling a rule means editing the file, which takes effect without a restart.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+
+from libs.schemas.rules import AlertRule
+from services.rules.provider import get_rule_engine
+
+logger = logging.getLogger("eagle.rules")
+
+router = APIRouter(prefix="/rules", tags=["rules"])
+
+
+@router.get("", response_model=list[AlertRule])
+def list_rules(
+    enabled_only: bool = Query(
+        False, description="Return only the rules currently in force."
+    ),
+) -> list[AlertRule]:
+    """Return the configured alert rules, in evaluation order."""
+    rules = get_rule_engine().rules
+    if enabled_only:
+        rules = [rule for rule in rules if rule.enabled]
+    return rules
+
+
+@router.get("/{rule_id}", response_model=AlertRule)
+def get_rule(rule_id: str) -> AlertRule:
+    """Return a single alert rule by id."""
+    for rule in get_rule_engine().rules:
+        if rule.id == rule_id:
+            return rule
+    raise HTTPException(status_code=404, detail=f"Alert rule {rule_id!r} not found")

--- a/config/alert_rules.example.yaml
+++ b/config/alert_rules.example.yaml
@@ -1,0 +1,81 @@
+# ── Eagle Configurable Alert Rules (example) ─────────────────────────────────
+#
+#   cp config/alert_rules.example.yaml config/alert_rules.yaml
+#
+# Copy this file to config/alert_rules.yaml (or point ALERT_RULES_PATH at it) to
+# switch alert rules on. While no rules file exists, Eagle keeps its default
+# behaviour and alerts on all suspicious activity.
+#
+# Rules decide which detected activity is worth notifying an operator about.
+# They narrow the default trigger conditions (zone entry + dwell + suspicious
+# action); they never widen them.
+#
+# Every matching field is optional and omitting it means "any":
+#   object_types     person | vehicle | bag | device, or any raw COCO class
+#                    (e.g. "car"). Groups expand to their member classes.
+#                    Only classes the tracker emits can match — today that is
+#                    'person', so vehicle and bag rules are inert until the
+#                    tracker tracks those classes.
+#   zones            zone names from config/zones.yaml
+#   action_hints     lingering | zone_entry | near_keypad | repeated_approach |
+#                    walking | standing | zone_exit | unknown
+#   min_confidence   0.0–1.0 detector confidence floor
+#   time_windows     start/end (HH:MM, may cross midnight) and optional days
+#   cooldown_seconds overrides REASONING_COOLDOWN_SECONDS for this rule
+#   enabled          set false to switch a rule off without deleting it
+#
+# Rules are evaluated top to bottom and the first match wins, so put the most
+# specific rules first. Edits are picked up automatically — no restart needed.
+#
+# Delete config/alert_rules.yaml (or disable every rule) to restore the default
+# behaviour of alerting on all suspicious activity.
+#
+# Note: rules that name object_types only match events carrying an object class.
+# Events written before Eagle recorded the class have none, so they will not
+# match a typed rule.
+
+rules:
+  # High-confidence people at the restricted door, at any hour.
+  - id: restricted_door_person
+    description: Person lingering or repeatedly approaching the secure door.
+    object_types: [person]
+    zones: [restricted_door]
+    action_hints: [lingering, near_keypad, repeated_approach]
+    min_confidence: 0.6
+
+  # Keypad tampering is always worth a look, regardless of dwell pattern.
+  - id: keypad_interaction
+    description: Anyone interacting with the access keypad.
+    object_types: [person]
+    zones: [keypad_area]
+    min_confidence: 0.5
+    cooldown_seconds: 120
+
+  # Corridor traffic is routine by day and worth a look at night.
+  - id: after_hours_corridor
+    description: Anyone in the corridor outside working hours.
+    zones: [safe_corridor]
+    min_confidence: 0.55
+    time_windows:
+      - start: "19:00"
+        end: "07:00"
+
+  # Weekend activity anywhere in the building is unusual.
+  - id: weekend_activity
+    description: Any person detected over the weekend.
+    object_types: [person]
+    min_confidence: 0.5
+    time_windows:
+      - start: "00:00"
+        end: "23:59"
+        days: [sat, sun]
+
+  # Example of a rule kept on file but switched off.
+  - id: daytime_corridor_person
+    description: Corridor foot traffic during the day — noisy, off by default.
+    enabled: false
+    object_types: [person]
+    zones: [safe_corridor]
+    time_windows:
+      - start: "07:00"
+        end: "19:00"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,7 @@ Eagle is an event-driven surveillance reasoning pipeline that converts raw video
 | Detection | YOLOv8/v9 | `FrameInput(frame, camera_id)` | `Detection(track_boxes, classes, confidence)` |
 | Tracking | ByteTrack / DeepSORT | Detection results | `TrackedObject(track_id, trajectory, dwell_time)` |
 | Temporal Memory | Redis Ring Buffer | `track_id + event payload` | Sliding event history (`last_n_events`) |
+| Alert Rules | YAML + Pydantic | `TrackSequence` + `config/alert_rules.yaml` | `RuleDecision(matched, rule_id, cooldown)` |
 | VLM Captioning | LLaVA-Next / Qwen-VL | Triggered frame sequence | Natural language captions |
 | LLM Reasoning | Mixtral / GPT-4o / Gemini | Caption sequence + policies | `Alert(label, confidence, reason)` |
 | Backend API | FastAPI + Celery | REST requests | JSON API responses |
@@ -32,10 +33,39 @@ C --> D[Temporal Memory<br/>services/memory/memory.py]
 
 D --> E{Event Trigger}
 
-E -->|Zone Entry / Dwell / Interaction| F[VLM Captioning<br/>services/reasoning/vlm.py]
+E -->|Zone Entry / Dwell / Interaction| R{Alert Rules<br/>services/rules/engine.py}
+
+R -->|No match| X[Suppressed]
+
+R -->|Match or no rules configured| F[VLM Captioning<br/>services/reasoning/vlm.py]
 
 F --> G[LLM Reasoning<br/>services/reasoning/llm.py]
 
 G --> H[FastAPI Backend<br/>apps/backend/main.py]
 
 H --> I[React Dashboard<br/>apps/dashboard]
+```
+
+---
+
+## Alert Rules
+
+Reasoning is expensive, so `services/memory/trigger.py` gates it. Operators can
+narrow that gate with rules in `config/alert_rules.yaml` — by object class, zone,
+action hint, confidence floor, and time of day.
+
+The engine (`services/rules/engine.py`) is pure: rules, activity, and the current
+time are all arguments, so a decision is reproducible in a test. Config loading
+and hot reload live in `libs/config/rule_loader.py`, keeping filesystem concerns
+out of the matcher.
+
+Two properties keep the feature safe to enable:
+
+- Rules only ever **narrow**. Activity must still clear the zone, dwell, and
+  suspicious-action gates, so a rule cannot manufacture an alert.
+- With no rule enabled the engine **abstains** rather than matching nothing, so
+  an absent or fully disabled config leaves the pipeline exactly as it was.
+
+Rules match on `TrackEvent.label`, which carries the tracked object's class.
+Events stored before that field existed have no class and therefore never match
+a rule that names `object_types`.

--- a/libs/config/rule_loader.py
+++ b/libs/config/rule_loader.py
@@ -1,0 +1,164 @@
+"""
+libs/config/rule_loader.py
+
+Loads configurable alert rules from a YAML file.  Follows the conventions of
+`zone_loader.py`:
+  - ALERT_RULES_PATH environment variable override
+  - Validation on load, with the offending rule named in the error
+  - Hot reload, so operators can enable or disable rules without a restart
+
+Reload is driven by the file's mtime rather than a background thread, because
+the rules are read on the request path: there is no thread to supervise, and a
+freshness check costs one `stat` at most every `rules_reload_seconds`.
+
+A missing rules file is not an error.  It yields an empty rule set, which the
+engine treats as "no opinion" so the pipeline keeps its default behaviour.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import ValidationError
+
+from libs.config.settings import settings
+from libs.schemas.rules import RuleSet
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_config_path() -> Path:
+    """Resolve the rules path from env var or settings."""
+    env_path = os.environ.get("ALERT_RULES_PATH")
+    return Path(env_path) if env_path else Path(settings.alert_rules_path)
+
+
+def load_rules(config_path: Optional[Path] = None) -> RuleSet:
+    """Load and validate alert rules from a YAML file.
+
+    Args:
+        config_path: Optional override. Falls back to the ALERT_RULES_PATH env
+                     var, then `settings.alert_rules_path`.
+
+    Returns:
+        The parsed RuleSet; empty when the file does not exist.
+
+    Raises:
+        ValueError: If the YAML is malformed or any rule fails validation.
+    """
+    path = config_path or _resolve_config_path()
+
+    if not path.exists():
+        logger.info(
+            "No alert rules file at '%s' — every event keeps the default "
+            "trigger behaviour.", path,
+        )
+        return RuleSet()
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in alert rules file '{path}': {exc}") from exc
+
+    if raw is None:
+        return RuleSet()
+    if not isinstance(raw, dict) or "rules" not in raw:
+        raise ValueError(f"Alert rules file '{path}' must contain a 'rules' key.")
+    if raw["rules"] is None:
+        return RuleSet()
+
+    try:
+        rule_set = RuleSet(rules=raw["rules"])
+    except ValidationError as exc:
+        raise ValueError(f"Invalid alert rule in '{path}': {exc}") from exc
+
+    logger.info(
+        "Loaded %d alert rule(s) from %s (%d enabled).",
+        len(rule_set.rules), path, len(rule_set.enabled_rules),
+    )
+    return rule_set
+
+
+class RuleConfigLoader:
+    """Thread-safe rule set with mtime-based hot reload.
+
+    Usage:
+        loader = RuleConfigLoader()
+        rules = loader.get_rules()      # reloads if the file changed
+    """
+
+    def __init__(
+        self,
+        config_path: Optional[Path] = None,
+        reload_interval: Optional[float] = None,
+    ) -> None:
+        self._config_path = config_path or _resolve_config_path()
+        self._reload_interval = (
+            settings.rules_reload_seconds if reload_interval is None else reload_interval
+        )
+        self._lock = threading.RLock()
+        self._rule_set = RuleSet()
+        self._last_mtime: Optional[float] = None
+        self._last_checked: float = 0.0
+
+        # Initial load. A broken file must not stop the process from starting,
+        # so it degrades to an empty rule set with the reason logged.
+        try:
+            self._reload()
+        except ValueError as exc:
+            logger.error("Alert rules disabled — %s", exc)
+
+    def get_rules(self) -> RuleSet:
+        """Return the current rule set, reloading first if the file changed."""
+        self._maybe_reload()
+        with self._lock:
+            return self._rule_set
+
+    def force_reload(self) -> RuleSet:
+        """Reload immediately, bypassing the freshness interval."""
+        try:
+            self._reload()
+        except ValueError as exc:
+            logger.error("Keeping previous alert rules — %s", exc)
+        with self._lock:
+            return self._rule_set
+
+    def _maybe_reload(self) -> None:
+        now = time.monotonic()
+        with self._lock:
+            if now - self._last_checked < self._reload_interval:
+                return
+            self._last_checked = now
+
+        try:
+            mtime = self._config_path.stat().st_mtime
+        except OSError:
+            # File removed since the last load; keep serving what we have.
+            return
+
+        if mtime == self._last_mtime:
+            return
+
+        try:
+            self._reload()
+        except ValueError as exc:
+            # Keep the last good rule set: a typo mid-edit must not silently
+            # widen or narrow what gets alerted on.
+            logger.error("Keeping previous alert rules — %s", exc)
+
+    def _reload(self) -> None:
+        rule_set = load_rules(self._config_path)
+        try:
+            mtime = self._config_path.stat().st_mtime
+        except OSError:
+            mtime = None
+        with self._lock:
+            self._rule_set = rule_set
+            self._last_mtime = mtime
+            self._last_checked = time.monotonic()

--- a/libs/config/settings.py
+++ b/libs/config/settings.py
@@ -61,6 +61,13 @@ class Settings(BaseSettings):
     policy_path: str = "policies/default.yaml"
     camera_id: str = "cam_01"
 
+    # ── Configurable alert rules ──────────────────────────────────────────
+    alert_rules_path: str = "config/alert_rules.yaml"
+    # Timezone that time-based rule windows are evaluated in.
+    rules_timezone: str = "UTC"
+    # Minimum seconds between rule-file freshness checks.
+    rules_reload_seconds: float = 30.0
+
     # ── Kafka ─────────────────────────────────────────────────────────────
     use_kafka: bool = False
     kafka_bootstrap_servers: str = "localhost:9092"

--- a/libs/schemas/memory.py
+++ b/libs/schemas/memory.py
@@ -38,6 +38,9 @@ class TrackEvent(BaseModel):
     camera_id:   str              = "cam_01"
     frame_id:    int
     timestamp_ms: float
+    # COCO class of the tracked object, e.g. 'person' or 'car'. Alert rules match
+    # on this; None for events written before it was recorded.
+    label:       Optional[str]    = None
     zone:        Optional[str]    = None   # zone name or None if not in any zone
     action_hint: ActionHint       = ActionHint.UNKNOWN
     temporal_action: Optional[str] = None

--- a/libs/schemas/rules.py
+++ b/libs/schemas/rules.py
@@ -1,0 +1,137 @@
+"""
+Schemas for configurable alert rules.
+
+A rule describes which detected activity is worth notifying an operator about.
+Every matching dimension is optional and an empty value means "any", so the
+narrowest useful rule is two lines of YAML:
+
+    - id: any_person
+      object_types: [person]
+
+Field names deliberately mirror the runtime data they are matched against —
+`TrackEvent.label`, `TrackEvent.zone`, `TrackEvent.confidence`, and
+`ActionHint` — so the config reads like the events it filters.
+"""
+from __future__ import annotations
+
+from datetime import datetime, time
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from libs.schemas.memory import ActionHint
+
+# Group aliases usable in `object_types` alongside raw COCO classes, so a rule
+# can say `vehicle` instead of enumerating every vehicle class YOLO emits.
+OBJECT_GROUPS: dict[str, frozenset[str]] = {
+    "person": frozenset({"person"}),
+    "vehicle": frozenset({"car", "truck", "bus", "motorcycle", "bicycle"}),
+    "bag": frozenset({"backpack", "handbag", "suitcase"}),
+    "device": frozenset({"cell phone", "laptop"}),
+}
+
+
+def resolve_object_types(object_types: list[str]) -> frozenset[str]:
+    """Expand group aliases to the concrete labels a detector emits.
+
+    Unknown names pass through unchanged so any COCO class can be named
+    directly without the taxonomy needing to know about it.
+    """
+    resolved: set[str] = set()
+    for entry in object_types:
+        key = entry.strip().lower()
+        resolved |= OBJECT_GROUPS.get(key, frozenset({key}))
+    return frozenset(resolved)
+
+
+class Weekday(str, Enum):
+    MON = "mon"
+    TUE = "tue"
+    WED = "wed"
+    THU = "thu"
+    FRI = "fri"
+    SAT = "sat"
+    SUN = "sun"
+
+
+_WEEKDAY_BY_INDEX = (
+    Weekday.MON, Weekday.TUE, Weekday.WED,
+    Weekday.THU, Weekday.FRI, Weekday.SAT, Weekday.SUN,
+)
+
+
+class RuleTimeWindow(BaseModel):
+    """A recurring daily window, optionally limited to certain weekdays.
+
+    Windows may cross midnight (`22:00`–`06:00`).  When `days` is set it is
+    checked against the weekday of the moment being tested, so a crossing
+    window applies to both the late-evening and early-morning portions of each
+    listed day.
+    """
+
+    start: time
+    end:   time
+    days:  list[Weekday] = Field(default_factory=list)
+
+    def contains(self, moment: datetime) -> bool:
+        if self.days and _WEEKDAY_BY_INDEX[moment.weekday()] not in self.days:
+            return False
+
+        current = moment.time()
+        if self.start <= self.end:
+            return self.start <= current <= self.end
+        # Crosses midnight: inside if after the start or before the end.
+        return current >= self.start or current <= self.end
+
+
+class AlertRule(BaseModel):
+    """One operator-defined condition for firing an alert.
+
+    All dimensions are ANDed together; a rule matches when every populated
+    dimension is satisfied.
+    """
+
+    id:      str  = Field(..., min_length=1, max_length=64)
+    enabled: bool = True
+
+    object_types:  list[str]        = Field(default_factory=list)
+    zones:         list[str]        = Field(default_factory=list)
+    action_hints:  list[ActionHint] = Field(default_factory=list)
+    time_windows:  list[RuleTimeWindow] = Field(default_factory=list)
+    min_confidence: float = Field(0.0, ge=0.0, le=1.0)
+
+    # Overrides settings.reasoning_cooldown_seconds for activity this rule matches,
+    # letting noisy rules be throttled harder than quiet ones.
+    cooldown_seconds: Optional[float] = Field(None, ge=0.0)
+    description: str = ""
+
+    @field_validator("object_types", "zones", mode="after")
+    @classmethod
+    def _strip_entries(cls, values: list[str]) -> list[str]:
+        return [v.strip() for v in values if v and v.strip()]
+
+    @property
+    def resolved_object_types(self) -> frozenset[str]:
+        """Concrete labels this rule accepts; empty means any."""
+        return resolve_object_types(self.object_types)
+
+
+class RuleSet(BaseModel):
+    """The parsed contents of an alert rules config file."""
+
+    rules: list[AlertRule] = Field(default_factory=list)
+
+    @property
+    def enabled_rules(self) -> list[AlertRule]:
+        return [rule for rule in self.rules if rule.enabled]
+
+    @field_validator("rules", mode="after")
+    @classmethod
+    def _reject_duplicate_ids(cls, rules: list[AlertRule]) -> list[AlertRule]:
+        seen: set[str] = set()
+        for rule in rules:
+            if rule.id in seen:
+                raise ValueError(f"duplicate rule id {rule.id!r}")
+            seen.add(rule.id)
+        return rules

--- a/services/memory/pipeline.py
+++ b/services/memory/pipeline.py
@@ -14,12 +14,12 @@ from libs.schemas.tracking import TrackedFrame
 from libs.schemas.memory   import TrackEvent
 from services.memory.action_classifier import classify_action
 from services.memory.memory import MemoryStore
-from services.memory.kafka_producer import KafkaEventProducer
 from libs.config.settings import settings
 
 if TYPE_CHECKING:
     from services.action_recognition.inference import ActionRecognizer
     from services.memory.memory import MemoryService
+    from services.memory.kafka_producer import KafkaEventProducer
 
 # Shared state for action classifier (tracks zone-entry history)
 _zone_entry_registry: dict[int, set[str]] = {}
@@ -27,9 +27,12 @@ _zone_entry_counts: dict[int, dict[str, int]] = {}
 _last_repeated_approach: dict[int, float] = {}
 _prev_objects: dict[int, object] = {}
 
-# Global Kafka producer instance
-_kafka_producer: KafkaEventProducer | None = None
+# Global Kafka producer instance. confluent_kafka is an optional dependency, so
+# it is imported only when Kafka publishing is switched on.
+_kafka_producer: "KafkaEventProducer | None" = None
 if settings.use_kafka:
+    from services.memory.kafka_producer import KafkaEventProducer
+
     _kafka_producer = KafkaEventProducer()
 
 
@@ -81,6 +84,7 @@ def process_tracked_frame(
             camera_id          = tracked.camera_id,
             frame_id           = tracked.frame_id,
             timestamp_ms       = time.time() * 1000,
+            label              = obj.label,
             zone               = obj.zones_present[0] if obj.zones_present else None,
             action_hint        = hint,
             bbox               = obj.bbox,

--- a/services/memory/trigger.py
+++ b/services/memory/trigger.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import logging
+from datetime import datetime
 from time import monotonic
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from libs.config.settings import settings
 from libs.schemas.memory import (
     TrackSequence,
     ActionHint,
 )
+from services.rules.engine import RuleContext, RuleDecision, RuleEngine
+
+logger = logging.getLogger(__name__)
 
 _reasoning_cooldowns: dict[int, float] = {}
 
@@ -24,8 +31,37 @@ def reset_cooldown(track_id: int) -> None:
     _reasoning_cooldowns.pop(track_id, None)
 
 
+def _rules_timezone() -> ZoneInfo:
+    try:
+        return ZoneInfo(settings.rules_timezone)
+    except (ZoneInfoNotFoundError, ValueError):
+        logger.warning(
+            "Unknown rules_timezone %r — evaluating time windows in UTC.",
+            settings.rules_timezone,
+        )
+        return ZoneInfo("UTC")
+
+
+def _evaluate_rules(seq: TrackSequence, engine: Optional[RuleEngine]) -> RuleDecision:
+    """Ask the configured rules whether this activity is worth alerting on."""
+    if engine is None:
+        from services.rules.provider import get_rule_engine
+
+        engine = get_rule_engine()
+
+    moment = datetime.now(tz=_rules_timezone())
+    if seq.events:
+        # Judge the activity at the time it happened, not at evaluation time.
+        moment = datetime.fromtimestamp(
+            seq.events[-1].timestamp_ms / 1000, tz=_rules_timezone()
+        )
+
+    return engine.evaluate(RuleContext.from_sequence(seq, moment=moment))
+
+
 def should_trigger_reasoning(
     seq: TrackSequence,
+    engine: Optional[RuleEngine] = None,
 ) -> bool:
     """
     Determine whether VLM/LLM reasoning should be triggered.
@@ -34,7 +70,15 @@ def should_trigger_reasoning(
     - Track is inside a restricted zone
     - Dwell time exceeds configured threshold
     - At least one suspicious action exists
+    - Activity matches an enabled alert rule, when any rule is configured
     - Track is not inside cooldown window
+
+    Configured rules narrow this gate; they never widen it. With no rules
+    configured the engine abstains and behaviour is unchanged.
+
+    Args:
+        seq:    The track's recent event sequence.
+        engine: Rule engine to consult. Defaults to the configured rule file.
     """
 
     if not seq.events:
@@ -54,15 +98,34 @@ def should_trigger_reasoning(
     if not has_suspicious_action:
         return False
 
+    # Configurable alert rules
+    decision = _evaluate_rules(seq, engine)
+    if decision.suppressed:
+        logger.debug(
+            "Rules suppressed track %d (considered: %s)",
+            seq.track_id, ", ".join(decision.rejected) or "none",
+        )
+        return False
+
     now = monotonic()
 
-    # Cooldown check
+    # Cooldown check — a matched rule may throttle harder than the global default
+    cooldown = (
+        decision.cooldown_seconds
+        if decision.cooldown_seconds is not None
+        else settings.reasoning_cooldown_seconds
+    )
     last_trigger = _reasoning_cooldowns.get(seq.track_id)
 
-    if last_trigger is not None and (now - last_trigger < settings.reasoning_cooldown_seconds):
+    if last_trigger is not None and (now - last_trigger < cooldown):
         return False
 
     # Start cooldown
     _reasoning_cooldowns[seq.track_id] = now
+
+    if decision.matched:
+        logger.info(
+            "Track %d matched alert rule %r", seq.track_id, decision.rule_id
+        )
 
     return True

--- a/services/rules/__init__.py
+++ b/services/rules/__init__.py
@@ -1,0 +1,23 @@
+"""
+Configurable alert rules.
+
+Operators describe which activity deserves a notification in
+`config/alert_rules.yaml`; those rules are evaluated before an alert is raised.
+
+    engine   — pure matching (no I/O, no clock)
+    provider — the process-wide engine, rebuilt when the config file changes
+
+Only the pure engine is re-exported here. `provider` reads YAML, so importing it
+is left to the caller that actually needs the configured rules — that keeps the
+matcher importable in environments without a YAML parser.
+
+With no rules configured the engine abstains and the pipeline keeps its default
+behaviour, so the feature is inert until an operator opts in.
+"""
+from services.rules.engine import RuleContext, RuleDecision, RuleEngine
+
+__all__ = [
+    "RuleContext",
+    "RuleDecision",
+    "RuleEngine",
+]

--- a/services/rules/engine.py
+++ b/services/rules/engine.py
@@ -1,0 +1,131 @@
+"""
+Alert rule evaluation.
+
+Pure matching logic: the rules, the activity, and the current time all arrive as
+arguments, so a decision is reproducible and testable without a config file or a
+frozen clock.
+
+Semantics
+---------
+Rules are an allow-list. When at least one rule is enabled, activity must match
+one of them to be alerted on. When no rule is enabled the engine *abstains*,
+and the caller keeps whatever behaviour it had before rules existed — that is
+what makes the feature safe to ship without a config file.
+
+Within a rule every populated dimension must be satisfied (AND); an empty
+dimension means "any". Rules are tested in file order and the first match wins,
+so the most specific rules belong at the top.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional, Sequence
+
+from libs.schemas.memory import ActionHint, TrackSequence
+from libs.schemas.rules import AlertRule, RuleSet
+
+
+@dataclass(frozen=True)
+class RuleContext:
+    """The activity being judged, flattened to what rules match on."""
+
+    object_labels: frozenset[str] = frozenset()
+    zones:         frozenset[str] = frozenset()
+    action_hints:  frozenset[ActionHint] = frozenset()
+    confidence:    float = 0.0
+    moment:        Optional[datetime] = None
+
+    @classmethod
+    def from_sequence(
+        cls, seq: TrackSequence, moment: Optional[datetime] = None
+    ) -> "RuleContext":
+        """Build a context from a track sequence.
+
+        Confidence is the highest seen in the sequence: a rule with a confidence
+        floor should fire when the detector was ever that sure, not only if it
+        was sure on the final frame.
+        """
+        return cls(
+            object_labels = frozenset(e.label for e in seq.events if e.label),
+            zones         = frozenset(e.zone for e in seq.events if e.zone),
+            action_hints  = frozenset(e.action_hint for e in seq.events),
+            confidence    = max((e.confidence for e in seq.events), default=0.0),
+            moment        = moment,
+        )
+
+
+@dataclass(frozen=True)
+class RuleDecision:
+    """Outcome of evaluating a context against a rule set."""
+
+    matched:   bool = False
+    # True when no rule was enabled, meaning the engine expressed no opinion.
+    abstained: bool = False
+    rule_id:   Optional[str] = None
+    cooldown_seconds: Optional[float] = None
+    # Rules that were considered and rejected, for explaining a suppression.
+    rejected:  tuple[str, ...] = field(default=())
+
+    @property
+    def suppressed(self) -> bool:
+        """True when the engine actively blocked this activity."""
+        return not self.matched and not self.abstained
+
+
+class RuleEngine:
+    """Evaluates activity against a set of alert rules."""
+
+    def __init__(self, rules: Sequence[AlertRule] | RuleSet | None = None) -> None:
+        if isinstance(rules, RuleSet):
+            self._rules = list(rules.rules)
+        else:
+            self._rules = list(rules or [])
+
+    @property
+    def rules(self) -> list[AlertRule]:
+        return list(self._rules)
+
+    def evaluate(self, context: RuleContext) -> RuleDecision:
+        """Decide whether `context` should raise an alert."""
+        enabled = [rule for rule in self._rules if rule.enabled]
+        if not enabled:
+            return RuleDecision(matched=False, abstained=True)
+
+        rejected: list[str] = []
+        for rule in enabled:
+            if self._matches(rule, context):
+                return RuleDecision(
+                    matched          = True,
+                    rule_id          = rule.id,
+                    cooldown_seconds = rule.cooldown_seconds,
+                    rejected         = tuple(rejected),
+                )
+            rejected.append(rule.id)
+
+        return RuleDecision(matched=False, rejected=tuple(rejected))
+
+    @staticmethod
+    def _matches(rule: AlertRule, context: RuleContext) -> bool:
+        if context.confidence < rule.min_confidence:
+            return False
+
+        accepted_labels = rule.resolved_object_types
+        if accepted_labels and not (accepted_labels & context.object_labels):
+            return False
+
+        if rule.zones and not (set(rule.zones) & context.zones):
+            return False
+
+        if rule.action_hints and not (set(rule.action_hints) & context.action_hints):
+            return False
+
+        if rule.time_windows:
+            # A time-scoped rule cannot be judged without a timestamp, so treat
+            # a missing one as a non-match rather than silently always firing.
+            if context.moment is None:
+                return False
+            if not any(window.contains(context.moment) for window in rule.time_windows):
+                return False
+
+        return True

--- a/services/rules/provider.py
+++ b/services/rules/provider.py
@@ -1,0 +1,38 @@
+"""
+Process-wide access to the configured rule engine.
+
+Keeping the loader here rather than in `engine.py` leaves the engine pure and
+gives the trigger path a single place to fetch rules from. The loader is created
+lazily so that importing the pipeline never touches the filesystem.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from libs.config.rule_loader import RuleConfigLoader
+from services.rules.engine import RuleEngine
+
+_lock = threading.Lock()
+_loader: Optional[RuleConfigLoader] = None
+
+
+def get_rule_engine() -> RuleEngine:
+    """Return an engine over the current rule file contents.
+
+    The loader reloads when the file changes, so enabling or disabling a rule
+    takes effect without a restart.
+    """
+    global _loader
+    if _loader is None:
+        with _lock:
+            if _loader is None:
+                _loader = RuleConfigLoader()
+    return RuleEngine(_loader.get_rules())
+
+
+def reset_rule_engine() -> None:
+    """Drop the cached loader. Used by tests and after a config path change."""
+    global _loader
+    with _lock:
+        _loader = None

--- a/tests/integration/test_rules.py
+++ b/tests/integration/test_rules.py
@@ -1,0 +1,132 @@
+"""
+tests/integration/test_rules.py
+
+Integration tests for the alert rules API.
+
+The endpoint reports what the pipeline is currently enforcing, so the tests
+point the loader at a temporary file and assert the response reflects it.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import apps.backend.main as backend
+from libs.config.rule_loader import RuleConfigLoader
+from services.rules import provider
+
+RULES_YAML = """
+rules:
+  - id: restricted_door_person
+    description: Person at the secure door.
+    object_types: [person]
+    zones: [restricted_door]
+    min_confidence: 0.6
+    cooldown_seconds: 90
+  - id: after_hours_vehicle
+    object_types: [vehicle]
+    time_windows:
+      - start: "19:00"
+        end: "07:00"
+  - id: noisy_corridor
+    enabled: false
+    zones: [safe_corridor]
+"""
+
+
+@pytest.fixture()
+def app(tmp_path: Path):
+    path = tmp_path / "alert_rules.yaml"
+    path.write_text(textwrap.dedent(RULES_YAML), encoding="utf-8")
+
+    original = provider._loader
+    provider._loader = RuleConfigLoader(path, reload_interval=0)
+    yield backend.app
+    provider._loader = original
+
+
+@pytest.fixture()
+def app_without_rules(tmp_path: Path):
+    original = provider._loader
+    provider._loader = RuleConfigLoader(tmp_path / "absent.yaml", reload_interval=0)
+    yield backend.app
+    provider._loader = original
+
+
+async def get(app, url: str):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.get(url)
+
+
+@pytest.mark.asyncio
+async def test_list_rules_returns_them_in_evaluation_order(app):
+    response = await get(app, "/rules")
+
+    assert response.status_code == 200
+    assert [rule["id"] for rule in response.json()] == [
+        "restricted_door_person",
+        "after_hours_vehicle",
+        "noisy_corridor",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_rules_exposes_enabled_state(app):
+    body = await get(app, "/rules")
+
+    states = {rule["id"]: rule["enabled"] for rule in body.json()}
+    assert states == {
+        "restricted_door_person": True,
+        "after_hours_vehicle": True,
+        "noisy_corridor": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_enabled_only_filters_disabled_rules(app):
+    response = await get(app, "/rules?enabled_only=true")
+
+    ids = [rule["id"] for rule in response.json()]
+    assert "noisy_corridor" not in ids
+    assert len(ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_rule_fields_survive_serialisation(app):
+    response = await get(app, "/rules/restricted_door_person")
+
+    assert response.status_code == 200
+    rule = response.json()
+    assert rule["object_types"] == ["person"]
+    assert rule["zones"] == ["restricted_door"]
+    assert rule["min_confidence"] == 0.6
+    assert rule["cooldown_seconds"] == 90
+    assert rule["description"] == "Person at the secure door."
+
+
+@pytest.mark.asyncio
+async def test_time_windows_are_serialised(app):
+    response = await get(app, "/rules/after_hours_vehicle")
+
+    window = response.json()["time_windows"][0]
+    assert window["start"].startswith("19:00")
+    assert window["end"].startswith("07:00")
+
+
+@pytest.mark.asyncio
+async def test_unknown_rule_returns_404(app):
+    response = await get(app, "/rules/does_not_exist")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_no_rules_file_returns_an_empty_list(app_without_rules):
+    """Absence of config is a valid state, not a server error."""
+    response = await get(app_without_rules, "/rules")
+
+    assert response.status_code == 200
+    assert response.json() == []

--- a/tests/test_alert_rules.py
+++ b/tests/test_alert_rules.py
@@ -1,0 +1,366 @@
+"""
+Unit tests for configurable alert rules: schema, object-group resolution, time
+windows, and the matching engine.
+
+The engine is pure, so these tests need no config file and no frozen clock.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, time, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from libs.schemas.memory import ActionHint, TrackEvent, TrackSequence
+from libs.schemas.rules import (
+    AlertRule,
+    RuleSet,
+    RuleTimeWindow,
+    resolve_object_types,
+)
+from services.rules.engine import RuleContext, RuleEngine
+
+# Friday 2026-08-14 and Saturday 2026-08-15
+FRIDAY_NOON = datetime(2026, 8, 14, 12, 0, tzinfo=timezone.utc)
+FRIDAY_NIGHT = datetime(2026, 8, 14, 23, 0, tzinfo=timezone.utc)
+SATURDAY_NOON = datetime(2026, 8, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def make_event(
+    label: str | None = "person",
+    zone: str | None = "restricted_door",
+    hint: ActionHint = ActionHint.LINGERING,
+    confidence: float = 0.9,
+    timestamp_ms: float = 0.0,
+) -> TrackEvent:
+    return TrackEvent(
+        track_id     = 1,
+        frame_id     = 0,
+        timestamp_ms = timestamp_ms,
+        label        = label,
+        zone         = zone,
+        action_hint  = hint,
+        confidence   = confidence,
+    )
+
+
+def make_context(moment: datetime | None = FRIDAY_NOON, **event_kwargs) -> RuleContext:
+    event = make_event(**event_kwargs)
+    seq = TrackSequence(
+        track_id      = 1,
+        events        = [event],
+        zones_visited = [event.zone] if event.zone else [],
+        total_dwell   = 10.0,
+    )
+    return RuleContext.from_sequence(seq, moment=moment)
+
+
+# ── Object group resolution ───────────────────────────────────────────────────
+
+def test_vehicle_group_expands_to_coco_classes():
+    resolved = resolve_object_types(["vehicle"])
+
+    assert {"car", "truck", "bus", "motorcycle", "bicycle"} <= resolved
+    assert "person" not in resolved
+
+
+def test_raw_coco_class_passes_through():
+    assert resolve_object_types(["car"]) == {"car"}
+
+
+def test_unknown_object_type_is_kept_verbatim():
+    """Any COCO class must be nameable without the taxonomy knowing it."""
+    assert resolve_object_types(["fire hydrant"]) == {"fire hydrant"}
+
+
+def test_group_names_are_case_insensitive():
+    assert resolve_object_types(["Vehicle"]) == resolve_object_types(["vehicle"])
+
+
+def test_groups_and_raw_classes_combine():
+    resolved = resolve_object_types(["person", "car"])
+
+    assert resolved == {"person", "car"}
+
+
+# ── Time windows ──────────────────────────────────────────────────────────────
+
+def test_window_matches_inside_range():
+    window = RuleTimeWindow(start=time(9, 0), end=time(17, 0))
+
+    assert window.contains(FRIDAY_NOON) is True
+
+
+def test_window_rejects_outside_range():
+    window = RuleTimeWindow(start=time(9, 0), end=time(17, 0))
+
+    assert window.contains(FRIDAY_NIGHT) is False
+
+
+def test_window_crossing_midnight_matches_late_evening():
+    window = RuleTimeWindow(start=time(19, 0), end=time(7, 0))
+
+    assert window.contains(FRIDAY_NIGHT) is True
+
+
+def test_window_crossing_midnight_matches_early_morning():
+    window = RuleTimeWindow(start=time(19, 0), end=time(7, 0))
+    early = datetime(2026, 8, 15, 3, 0, tzinfo=timezone.utc)
+
+    assert window.contains(early) is True
+
+
+def test_window_crossing_midnight_rejects_midday():
+    window = RuleTimeWindow(start=time(19, 0), end=time(7, 0))
+
+    assert window.contains(FRIDAY_NOON) is False
+
+
+def test_window_limited_to_weekdays_rejects_other_days():
+    window = RuleTimeWindow(start=time(0, 0), end=time(23, 59), days=["sat", "sun"])
+
+    assert window.contains(SATURDAY_NOON) is True
+    assert window.contains(FRIDAY_NOON) is False
+
+
+def test_window_parses_hh_mm_strings_from_yaml():
+    window = RuleTimeWindow(start="22:00", end="06:00")
+
+    assert window.start == time(22, 0)
+    assert window.end == time(6, 0)
+
+
+# ── Rule schema ───────────────────────────────────────────────────────────────
+
+def test_rule_defaults_to_enabled_and_unrestricted():
+    rule = AlertRule(id="any")
+
+    assert rule.enabled is True
+    assert rule.object_types == []
+    assert rule.min_confidence == 0.0
+
+
+def test_blank_entries_are_stripped():
+    rule = AlertRule(id="r", object_types=[" person ", ""], zones=["  dock  "])
+
+    assert rule.object_types == ["person"]
+    assert rule.zones == ["dock"]
+
+
+def test_confidence_outside_unit_range_is_rejected():
+    with pytest.raises(ValueError):
+        AlertRule(id="r", min_confidence=1.5)
+
+
+def test_empty_rule_id_is_rejected():
+    with pytest.raises(ValueError):
+        AlertRule(id="")
+
+
+def test_duplicate_rule_ids_are_rejected():
+    with pytest.raises(ValueError, match="duplicate rule id"):
+        RuleSet(rules=[AlertRule(id="same"), AlertRule(id="same")])
+
+
+def test_rule_set_reports_enabled_rules():
+    rule_set = RuleSet(
+        rules=[AlertRule(id="on"), AlertRule(id="off", enabled=False)]
+    )
+
+    assert [r.id for r in rule_set.enabled_rules] == ["on"]
+
+
+# ── Engine: abstention ────────────────────────────────────────────────────────
+
+def test_engine_abstains_with_no_rules():
+    """No rules configured must mean no opinion, so callers keep their default."""
+    decision = RuleEngine([]).evaluate(make_context())
+
+    assert decision.abstained is True
+    assert decision.matched is False
+    assert decision.suppressed is False
+
+
+def test_engine_abstains_when_every_rule_is_disabled():
+    engine = RuleEngine([AlertRule(id="off", enabled=False, object_types=["person"])])
+
+    decision = engine.evaluate(make_context())
+
+    assert decision.abstained is True
+    assert decision.suppressed is False
+
+
+def test_disabled_rule_cannot_match():
+    engine = RuleEngine([
+        AlertRule(id="off", enabled=False, object_types=["person"]),
+        AlertRule(id="on", object_types=["car"]),
+    ])
+
+    decision = engine.evaluate(make_context(label="person"))
+
+    assert decision.matched is False
+    assert decision.suppressed is True
+
+
+# ── Engine: matching dimensions ───────────────────────────────────────────────
+
+def test_unrestricted_rule_matches_anything():
+    decision = RuleEngine([AlertRule(id="any")]).evaluate(make_context())
+
+    assert decision.matched is True
+    assert decision.rule_id == "any"
+
+
+def test_object_type_must_match():
+    engine = RuleEngine([AlertRule(id="vehicles", object_types=["vehicle"])])
+
+    assert engine.evaluate(make_context(label="car")).matched is True
+    assert engine.evaluate(make_context(label="person")).matched is False
+
+
+def test_zone_must_match():
+    engine = RuleEngine([AlertRule(id="door", zones=["restricted_door"])])
+
+    assert engine.evaluate(make_context(zone="restricted_door")).matched is True
+    assert engine.evaluate(make_context(zone="safe_corridor")).matched is False
+
+
+def test_action_hint_must_match():
+    engine = RuleEngine([
+        AlertRule(id="lingering", action_hints=[ActionHint.LINGERING])
+    ])
+
+    assert engine.evaluate(make_context(hint=ActionHint.LINGERING)).matched is True
+    assert engine.evaluate(make_context(hint=ActionHint.WALKING)).matched is False
+
+
+def test_confidence_floor_is_enforced():
+    engine = RuleEngine([AlertRule(id="confident", min_confidence=0.8)])
+
+    assert engine.evaluate(make_context(confidence=0.9)).matched is True
+    assert engine.evaluate(make_context(confidence=0.5)).matched is False
+
+
+def test_confidence_floor_is_inclusive():
+    engine = RuleEngine([AlertRule(id="confident", min_confidence=0.8)])
+
+    assert engine.evaluate(make_context(confidence=0.8)).matched is True
+
+
+def test_dimensions_are_anded_together():
+    engine = RuleEngine([
+        AlertRule(id="strict", object_types=["person"], zones=["restricted_door"])
+    ])
+
+    assert engine.evaluate(make_context(label="person", zone="restricted_door")).matched
+    assert not engine.evaluate(make_context(label="person", zone="safe_corridor")).matched
+    assert not engine.evaluate(make_context(label="car", zone="restricted_door")).matched
+
+
+def test_time_scoped_rule_respects_the_window():
+    engine = RuleEngine([
+        AlertRule(id="after_hours", time_windows=[RuleTimeWindow(start="19:00", end="07:00")])
+    ])
+
+    assert engine.evaluate(make_context(moment=FRIDAY_NIGHT)).matched is True
+    assert engine.evaluate(make_context(moment=FRIDAY_NOON)).matched is False
+
+
+def test_time_scoped_rule_does_not_match_without_a_timestamp():
+    """Absent a timestamp a time-scoped rule must not fire unconditionally."""
+    engine = RuleEngine([
+        AlertRule(id="after_hours", time_windows=[RuleTimeWindow(start="19:00", end="07:00")])
+    ])
+
+    assert engine.evaluate(make_context(moment=None)).matched is False
+
+
+def test_events_without_an_object_class_cannot_match_a_typed_rule():
+    """Events predating object-class capture must not match person/vehicle rules."""
+    engine = RuleEngine([AlertRule(id="people", object_types=["person"])])
+
+    assert engine.evaluate(make_context(label=None)).matched is False
+
+
+def test_events_without_an_object_class_still_match_untyped_rules():
+    engine = RuleEngine([AlertRule(id="any", zones=["restricted_door"])])
+
+    assert engine.evaluate(make_context(label=None)).matched is True
+
+
+# ── Engine: ordering and metadata ─────────────────────────────────────────────
+
+def test_first_matching_rule_wins():
+    engine = RuleEngine([
+        AlertRule(id="specific", object_types=["person"], zones=["restricted_door"]),
+        AlertRule(id="general", object_types=["person"]),
+    ])
+
+    assert engine.evaluate(make_context()).rule_id == "specific"
+
+
+def test_rejected_rules_are_reported_for_diagnosis():
+    engine = RuleEngine([
+        AlertRule(id="vehicles", object_types=["vehicle"]),
+        AlertRule(id="people", object_types=["person"]),
+    ])
+
+    decision = engine.evaluate(make_context(label="person"))
+
+    assert decision.rule_id == "people"
+    assert decision.rejected == ("vehicles",)
+
+
+def test_matched_rule_exposes_its_cooldown_override():
+    engine = RuleEngine([AlertRule(id="throttled", cooldown_seconds=120.0)])
+
+    assert engine.evaluate(make_context()).cooldown_seconds == 120.0
+
+
+def test_engine_accepts_a_rule_set():
+    engine = RuleEngine(RuleSet(rules=[AlertRule(id="any")]))
+
+    assert [r.id for r in engine.rules] == ["any"]
+
+
+# ── Context construction ──────────────────────────────────────────────────────
+
+def test_context_uses_highest_confidence_in_the_sequence():
+    """A confidence floor should pass if the detector was ever that certain."""
+    seq = TrackSequence(
+        track_id = 1,
+        events   = [
+            make_event(confidence=0.4),
+            make_event(confidence=0.95),
+            make_event(confidence=0.5),
+        ],
+        zones_visited = ["restricted_door"],
+    )
+
+    assert RuleContext.from_sequence(seq).confidence == pytest.approx(0.95)
+
+
+def test_context_collects_every_label_zone_and_hint():
+    seq = TrackSequence(
+        track_id = 1,
+        events   = [
+            make_event(label="person", zone="safe_corridor", hint=ActionHint.WALKING),
+            make_event(label="backpack", zone="restricted_door", hint=ActionHint.LINGERING),
+        ],
+    )
+
+    context = RuleContext.from_sequence(seq)
+
+    assert context.object_labels == {"person", "backpack"}
+    assert context.zones == {"safe_corridor", "restricted_door"}
+    assert context.action_hints == {ActionHint.WALKING, ActionHint.LINGERING}
+
+
+def test_context_from_empty_sequence_is_harmless():
+    context = RuleContext.from_sequence(TrackSequence(track_id=1))
+
+    assert context.confidence == 0.0
+    assert context.object_labels == frozenset()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -436,3 +436,58 @@ def test_reasoning_result_id_present_after_set(store):
     store.store_event(evt)
     seq = store.get_sequence(track_id=51)
     assert seq.events[0].reasoning_result_id == "test-alert-id-123"
+
+
+# ── Object class capture ──────────────────────────────────────────────────────
+
+def make_tracked_object(track_id: int, label: str):
+    from libs.schemas.tracking import TrackedObject, TrackState
+
+    return TrackedObject(
+        track_id=track_id, label=label, bbox=[100, 80, 200, 300],
+        confidence=0.9, center=(150, 190), dwell_time_frames=1,
+        dwell_time_seconds=0.0, state=TrackState.ACTIVE,
+        zones_present=["restricted_door"],
+    )
+
+
+def test_label_defaults_to_none_for_legacy_events():
+    """Events stored before the object class was captured must stay readable."""
+    assert make_event(60, 0).label is None
+
+
+def test_label_survives_a_storage_round_trip(store):
+    evt = make_event(61, 0, zone="restricted_door")
+    evt.label = "person"
+    store.store_event(evt)
+
+    assert store.get_sequence(track_id=61).events[0].label == "person"
+
+
+def test_pipeline_records_the_tracked_object_class(store):
+    """Alert rules match on the object class, so the pipeline must persist it."""
+    from libs.schemas.tracking import TrackedFrame
+    from services.memory.pipeline import process_tracked_frame
+
+    frame = TrackedFrame(
+        frame_id=1, camera_id="cam_01", timestamp_ms=time.time() * 1000, fps=30.0,
+        tracks=[make_tracked_object(62, "person")],
+    )
+
+    events = process_tracked_frame(frame, store)
+
+    assert events[0].label == "person"
+    assert store.get_sequence(track_id=62).events[0].label == "person"
+
+
+def test_pipeline_preserves_non_person_classes(store):
+    """The class is taken from the track, not assumed to be 'person'."""
+    from libs.schemas.tracking import TrackedFrame
+    from services.memory.pipeline import process_tracked_frame
+
+    frame = TrackedFrame(
+        frame_id=1, camera_id="cam_01", timestamp_ms=time.time() * 1000, fps=30.0,
+        tracks=[make_tracked_object(63, "backpack")],
+    )
+
+    assert process_tracked_frame(frame, store)[0].label == "backpack"

--- a/tests/test_rule_loader.py
+++ b/tests/test_rule_loader.py
@@ -1,0 +1,197 @@
+"""
+Tests for loading alert rules from YAML.
+
+A rules file is operator-editable and read on the request path, so the loader
+has to be forgiving about absence and unforgiving about ambiguity: a missing
+file disables the feature, while a malformed one must never silently change what
+gets alerted on.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from libs.config.rule_loader import RuleConfigLoader, load_rules
+
+VALID_RULES = """
+rules:
+  - id: restricted_door_person
+    object_types: [person]
+    zones: [restricted_door]
+    min_confidence: 0.6
+  - id: after_hours_vehicle
+    object_types: [vehicle]
+    time_windows:
+      - start: "19:00"
+        end: "07:00"
+    enabled: false
+"""
+
+
+def write_rules(tmp_path: Path, content: str, name: str = "alert_rules.yaml") -> Path:
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+# ── Loading ───────────────────────────────────────────────────────────────────
+
+def test_loads_and_orders_rules(tmp_path):
+    rule_set = load_rules(write_rules(tmp_path, VALID_RULES))
+
+    assert [r.id for r in rule_set.rules] == [
+        "restricted_door_person",
+        "after_hours_vehicle",
+    ]
+
+
+def test_enabled_flag_is_honoured(tmp_path):
+    rule_set = load_rules(write_rules(tmp_path, VALID_RULES))
+
+    assert [r.id for r in rule_set.enabled_rules] == ["restricted_door_person"]
+
+
+def test_nested_fields_are_parsed(tmp_path):
+    rule_set = load_rules(write_rules(tmp_path, VALID_RULES))
+    vehicle_rule = rule_set.rules[1]
+
+    assert vehicle_rule.time_windows[0].start.hour == 19
+    assert "car" in vehicle_rule.resolved_object_types
+
+
+def test_missing_file_yields_an_empty_rule_set(tmp_path):
+    """Absence is the default state and must not raise."""
+    rule_set = load_rules(tmp_path / "does_not_exist.yaml")
+
+    assert rule_set.rules == []
+    assert rule_set.enabled_rules == []
+
+
+def test_empty_file_yields_an_empty_rule_set(tmp_path):
+    assert load_rules(write_rules(tmp_path, "")).rules == []
+
+
+def test_null_rules_key_yields_an_empty_rule_set(tmp_path):
+    assert load_rules(write_rules(tmp_path, "rules:\n")).rules == []
+
+
+def test_the_shipped_example_config_is_valid():
+    """The example operators are told to copy must actually load."""
+    example = Path(__file__).parents[1] / "config" / "alert_rules.example.yaml"
+
+    rule_set = load_rules(example)
+
+    assert len(rule_set.rules) >= 1
+    assert any(r.enabled for r in rule_set.rules)
+
+
+# ── Rejection ─────────────────────────────────────────────────────────────────
+
+def test_malformed_yaml_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match="Invalid YAML"):
+        load_rules(write_rules(tmp_path, "rules: [unclosed\n"))
+
+
+def test_missing_rules_key_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match="must contain a 'rules' key"):
+        load_rules(write_rules(tmp_path, "policies: []\n"))
+
+
+def test_invalid_rule_names_the_file(tmp_path):
+    content = """
+    rules:
+      - id: bad
+        min_confidence: 5.0
+    """
+    with pytest.raises(ValueError, match="Invalid alert rule"):
+        load_rules(write_rules(tmp_path, content))
+
+
+def test_duplicate_ids_are_rejected(tmp_path):
+    content = """
+    rules:
+      - id: same
+      - id: same
+    """
+    with pytest.raises(ValueError, match="Invalid alert rule"):
+        load_rules(write_rules(tmp_path, content))
+
+
+# ── Env override ──────────────────────────────────────────────────────────────
+
+def test_env_var_overrides_the_configured_path(tmp_path, monkeypatch):
+    path = write_rules(tmp_path, VALID_RULES, name="custom.yaml")
+    monkeypatch.setenv("ALERT_RULES_PATH", str(path))
+
+    assert len(load_rules().rules) == 2
+
+
+# ── Hot reload ────────────────────────────────────────────────────────────────
+
+def test_loader_serves_rules_from_the_file(tmp_path):
+    loader = RuleConfigLoader(write_rules(tmp_path, VALID_RULES), reload_interval=0)
+
+    assert len(loader.get_rules().rules) == 2
+
+
+def test_loader_picks_up_edits(tmp_path):
+    """Enabling a rule must take effect without a restart."""
+    path = write_rules(tmp_path, VALID_RULES)
+    loader = RuleConfigLoader(path, reload_interval=0)
+    assert len(loader.get_rules().enabled_rules) == 1
+
+    path.write_text(
+        textwrap.dedent(
+            """
+            rules:
+              - id: everything
+            """
+        ),
+        encoding="utf-8",
+    )
+    # mtime resolution can be coarse, so make the change unambiguous.
+    os.utime(path, (0, 0))
+
+    assert [r.id for r in loader.get_rules().rules] == ["everything"]
+
+
+def test_loader_keeps_last_good_rules_when_an_edit_breaks(tmp_path):
+    """A typo mid-edit must not widen or narrow what gets alerted on."""
+    path = write_rules(tmp_path, VALID_RULES)
+    loader = RuleConfigLoader(path, reload_interval=0)
+
+    path.write_text("rules: [unclosed\n", encoding="utf-8")
+    os.utime(path, (0, 0))
+
+    assert len(loader.get_rules().rules) == 2
+
+
+def test_loader_starts_empty_when_the_file_is_broken(tmp_path):
+    """A broken file at startup must not stop the process from booting."""
+    loader = RuleConfigLoader(write_rules(tmp_path, "rules: [unclosed\n"))
+
+    assert loader.get_rules().rules == []
+
+
+def test_loader_tolerates_a_deleted_file(tmp_path):
+    path = write_rules(tmp_path, VALID_RULES)
+    loader = RuleConfigLoader(path, reload_interval=0)
+    path.unlink()
+
+    assert len(loader.get_rules().rules) == 2
+
+
+def test_force_reload_bypasses_the_freshness_interval(tmp_path):
+    path = write_rules(tmp_path, VALID_RULES)
+    loader = RuleConfigLoader(path, reload_interval=3600)
+
+    path.write_text("rules:\n  - id: only_one\n", encoding="utf-8")
+    os.utime(path, (0, 0))
+
+    assert [r.id for r in loader.force_reload().rules] == ["only_one"]

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -7,10 +7,13 @@ from libs.schemas.memory import (
     ActionHint,
 )
 
+from libs.schemas.rules import AlertRule, RuleTimeWindow
+
 from services.memory.trigger import (
     should_trigger_reasoning,
     reset_cooldown,
 )
+from services.rules.engine import RuleEngine
 
 
 @pytest.fixture(autouse=True)
@@ -110,3 +113,132 @@ def test_reset_cooldown_allows_retrigger():
     assert first is True
     assert second is False
     assert third is True
+
+
+# ── Configurable alert rules ──────────────────────────────────────────────────
+
+def make_rule_sequence(
+    label: str | None = "person",
+    zone: str = "restricted_door",
+    dwell: float = 10.0,
+    track_id: int = 1,
+    action: ActionHint = ActionHint.LINGERING,
+    confidence: float = 0.9,
+    timestamp_ms: float = 1_755_000_000_000,
+):
+    """A sequence carrying the fields rules match on."""
+    event = TrackEvent(
+        track_id=track_id,
+        frame_id=1,
+        timestamp_ms=timestamp_ms,
+        label=label,
+        zone=zone,
+        action_hint=action,
+        dwell_time_seconds=dwell,
+        confidence=confidence,
+    )
+    return TrackSequence(
+        track_id=track_id,
+        events=[event],
+        total_dwell=dwell,
+        zones_visited=[zone],
+    )
+
+
+def test_no_rules_configured_keeps_default_behaviour():
+    """The engine abstains with an empty rule set, so the gate is unchanged."""
+    reset_cooldown(400)
+    seq = make_rule_sequence(track_id=400)
+
+    assert should_trigger_reasoning(seq, engine=RuleEngine([])) is True
+
+
+def test_matching_rule_allows_the_trigger():
+    reset_cooldown(401)
+    engine = RuleEngine([AlertRule(id="people", object_types=["person"])])
+    seq = make_rule_sequence(track_id=401, label="person")
+
+    assert should_trigger_reasoning(seq, engine=engine) is True
+
+
+def test_non_matching_rule_suppresses_the_trigger():
+    reset_cooldown(402)
+    engine = RuleEngine([AlertRule(id="vehicles", object_types=["vehicle"])])
+    seq = make_rule_sequence(track_id=402, label="person")
+
+    assert should_trigger_reasoning(seq, engine=engine) is False
+
+
+def test_rules_cannot_widen_the_gate():
+    """A permissive rule must not bypass the dwell threshold."""
+    reset_cooldown(403)
+    engine = RuleEngine([AlertRule(id="everything")])
+    seq = make_rule_sequence(track_id=403, dwell=0.5)
+
+    assert should_trigger_reasoning(seq, engine=engine) is False
+
+
+def test_zone_scoped_rule_filters_by_zone():
+    reset_cooldown(404)
+    engine = RuleEngine([AlertRule(id="door_only", zones=["restricted_door"])])
+
+    assert should_trigger_reasoning(
+        make_rule_sequence(track_id=404, zone="restricted_door"), engine=engine
+    ) is True
+    reset_cooldown(405)
+    assert should_trigger_reasoning(
+        make_rule_sequence(track_id=405, zone="safe_corridor"), engine=engine
+    ) is False
+
+
+def test_confidence_floor_suppresses_weak_detections():
+    reset_cooldown(406)
+    engine = RuleEngine([AlertRule(id="confident", min_confidence=0.8)])
+    seq = make_rule_sequence(track_id=406, confidence=0.4)
+
+    assert should_trigger_reasoning(seq, engine=engine) is False
+
+
+def test_disabled_rule_is_ignored_and_engine_abstains():
+    """Disabling the only rule restores default behaviour rather than muting all."""
+    reset_cooldown(407)
+    engine = RuleEngine([
+        AlertRule(id="off", enabled=False, object_types=["vehicle"])
+    ])
+    seq = make_rule_sequence(track_id=407, label="person")
+
+    assert should_trigger_reasoning(seq, engine=engine) is True
+
+
+def test_per_rule_cooldown_overrides_the_global_default():
+    """A rule with a longer cooldown throttles harder than the global setting."""
+    reset_cooldown(408)
+    engine = RuleEngine([AlertRule(id="throttled", cooldown_seconds=3600.0)])
+    seq = make_rule_sequence(track_id=408)
+
+    assert should_trigger_reasoning(seq, engine=engine) is True
+    assert should_trigger_reasoning(seq, engine=engine) is False
+
+
+def test_time_scoped_rule_uses_the_event_timestamp():
+    """Rules judge activity when it happened, not when it is evaluated."""
+    engine = RuleEngine([
+        AlertRule(id="after_hours", time_windows=[RuleTimeWindow(start="19:00", end="07:00")])
+    ])
+    # 2026-08-14 23:30 UTC — inside the window
+    reset_cooldown(409)
+    inside = make_rule_sequence(track_id=409, timestamp_ms=1_755_214_200_000)
+    # 2026-08-14 12:00 UTC — outside it
+    reset_cooldown(410)
+    outside = make_rule_sequence(track_id=410, timestamp_ms=1_755_172_800_000)
+
+    assert should_trigger_reasoning(inside, engine=engine) is True
+    assert should_trigger_reasoning(outside, engine=engine) is False
+
+
+def test_legacy_events_without_a_label_do_not_match_typed_rules():
+    reset_cooldown(411)
+    engine = RuleEngine([AlertRule(id="people", object_types=["person"])])
+    seq = make_rule_sequence(track_id=411, label=None)
+
+    assert should_trigger_reasoning(seq, engine=engine) is False


### PR DESCRIPTION
## Summary

Adds a rule engine so operators can decide which suspicious activity actually raises an alert, instead of every zone-entry-plus-dwell event reaching the reasoning layer. Rules live in `config/alert_rules.yaml`, are validated on load, and are re-read when the file changes — no restart, no code edit.

The engine **narrows** the existing trigger; it never widens it. Activity must still clear the zone, dwell, and suspicious-action gates, so a permissive rule cannot manufacture an alert. With no rule enabled the engine abstains rather than matching nothing, which is what makes this safe to merge: an absent or fully disabled config leaves the pipeline behaving exactly as it does today.

Closes #183

## Deliverables from the issue

- [x] **Person detection alerts** — `object_types: [person]`, matched against the tracked object's class
- [x] **Confidence threshold** — `min_confidence`, checked against the highest confidence in the sequence
- [x] **Zone-based alerts** — `zones`, using the names already defined in `config/zones.yaml`
- [x] **Time-based rules** — `time_windows` with `HH:MM` ranges that may cross midnight, plus optional `days`
- [x] **Enable/Disable rules** — `enabled: false` switches a rule off in place, applied live
- [ ] **Vehicle alerts** — *expressible but inert today, see below*

`object_types: [vehicle]` parses, validates, and matches correctly in the engine (there are tests for it), but it cannot fire in the live pipeline yet: `services/tracking/tracker.py` drops every non-person detection before DeepSORT and hardcodes `label = "person"`. Making vehicle alerts real means multi-class tracking — ReID, action hints, and dwell semantics all currently assume people — which is a substantial feature of its own and would change what gets tracked for every existing deployment. Rather than add vehicle classes to the detector and ship a rule that silently never matches, the taxonomy is in place and the limitation is documented in the README and the example config. Happy to open a follow-up issue for multi-class tracking if you'd like.

## How a rule looks

Rules are off until the file exists:

```bash
cp config/alert_rules.example.yaml config/alert_rules.yaml
```

```yaml
rules:
  - id: restricted_door_person
    description: Person lingering or repeatedly approaching the secure door.
    object_types: [person]
    zones: [restricted_door]
    action_hints: [lingering, near_keypad, repeated_approach]
    min_confidence: 0.6

  - id: after_hours_corridor
    zones: [safe_corridor]
    time_windows:
      - start: "19:00"      # crosses midnight
        end: "07:00"
    cooldown_seconds: 120    # overrides REASONING_COOLDOWN_SECONDS for this rule

  - id: daytime_corridor_person
    enabled: false           # kept on file, switched off
    zones: [safe_corridor]
```

Every dimension is optional and an omitted one means "any". Populated dimensions are ANDed, rules are tried top to bottom, and the first match wins — so specific rules go first. `object_types` accepts the group aliases `person`, `vehicle`, `bag`, `device` or any raw COCO class.

## API

`GET /rules` reports what the pipeline is currently enforcing, in evaluation order. It's read-only on purpose: the YAML file is the source of truth, and it hot-reloads, so there's no second write path to keep consistent.

| Endpoint | Purpose |
|---|---|
| `GET /rules` | All rules, in evaluation order |
| `GET /rules?enabled_only=true` | Only the rules currently in force |
| `GET /rules/{rule_id}` | One rule, `404` if unknown |

Picked up automatically by the existing router auto-discovery — no registration edit.

## Design

`services/rules/engine.py` is pure: the rules, the activity, and the current time all arrive as arguments, so a decision is reproducible in a test with no config file and no frozen clock. YAML parsing and reload live in `libs/config/rule_loader.py`, and `services/rules/provider.py` holds the process-wide instance, keeping filesystem concerns out of the matcher.

Three behaviours worth reviewing:

- **A malformed edit keeps the last valid rules in force**, logging the reason. A typo mid-edit must not silently widen or narrow what gets alerted on. A file that is already broken at startup degrades to empty rather than stopping the process.
- **Reload is driven by mtime, not a background thread.** Rules are read on the request path, so there's no thread to supervise, and the freshness check costs one `stat` at most every `RULES_RELOAD_SECONDS`. This deviates from `zone_loader.py`'s thread; a shared base class would have forced one strategy onto both.
- **Time windows are evaluated at the event's timestamp**, not at evaluation time, so a late-arriving event is judged by when it actually happened. `RULES_TIMEZONE` sets the site's timezone; an unknown value falls back to UTC with a warning.

### Prerequisite: the object class was never persisted

Rules match on object type, but `TrackEvent` had no field for it — so this PR adds `TrackEvent.label`, populated in `services/memory/pipeline.py` from the tracked object's class and in `POST /ingest` from the request body. It defaults to `None`, so events already in Redis stay readable; they simply never match a rule that names `object_types`, which is pinned by a test.

### Why the config ships as `.example`

Shipping a populated `config/alert_rules.yaml` would activate the engine for everyone on upgrade, suppressing alerts that fire today. It ships as `config/alert_rules.example.yaml` for operators to copy, following the `.env.example` convention, and `config/alert_rules.yaml` is gitignored so local rules can't be committed by accident.

## Testing

78 new tests, all passing:

- `tests/test_alert_rules.py` (39) — group expansion, midnight-crossing and weekday windows, per-dimension matching, AND semantics, first-match-wins, abstention with no or all-disabled rules, and the inclusive confidence boundary.
- `tests/test_rule_loader.py` (18) — valid load and ordering, missing/empty/null-key files, malformed YAML, duplicate ids, the `ALERT_RULES_PATH` override, hot reload, keeping the last good rules through a broken edit, and a check that the shipped example config actually loads.
- `tests/integration/test_rules.py` (7) — the endpoints over HTTP, including `404` and the no-config-file case.
- `tests/test_trigger.py` (+10) — the gate itself: default behaviour preserved with no rules, suppression on non-match, that a permissive rule cannot bypass the dwell threshold, per-rule cooldown, and event-timestamp window evaluation.
- `tests/test_memory.py` (+4) — the object class reaching storage, including a non-person class and the legacy `None` default.

`341 passed` locally, excluding eight modules needing heavy ML dependencies (`ultralytics`, `deep_sort_realtime`, `matplotlib`, Kafka) and `tests/integration/test_backend.py`. `ruff check` is clean on every touched path. Also verified end to end against the real config path: creating, editing, disabling, and breaking the rules file while running, with the trigger and `GET /rules` both tracking the file live.

## Notes for reviewers

- **Two incidental fixes were needed to keep CI green.** `services/memory/pipeline.py` imported `confluent_kafka` unconditionally, though it is undeclared in every requirements file and only used when `USE_KAFKA` is set — that made the module unimportable in CI, so it is now imported only when Kafka is enabled. Separately, `services/rules/__init__.py` exports only the pure engine, not the YAML-reading provider, so PyYAML doesn't become a hard import for the memory package that `phase3-tests.yml` doesn't install.
- **`tests/integration/test_backend.py` already fails on `main`** (11 errors — it patches a `backend._redis` attribute that doesn't exist). Unrelated to this PR, and no workflow runs that file.
- **No dashboard UI here.** The follow-up toggle can read `GET /rules` directly; I left it out to keep this reviewable and because writes would need a second source of truth alongside the YAML file.
- New env vars are documented in `.env.example`: `ALERT_RULES_PATH`, `RULES_TIMEZONE`, `RULES_RELOAD_SECONDS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable YAML alert rules with matching by object type, zone, action, confidence, time window, and cooldown.
  * Added live rule reloading without restarting the service.
  * Added read-only APIs to list, filter, and inspect alert rules.
  * Events now retain tracked object labels for more precise alert matching.
* **Documentation**
  * Added configuration guidance, rule examples, matching behavior, and API documentation.
* **Bug Fixes**
  * Preserved the last valid rule configuration when edited rules contain errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->